### PR TITLE
✨ Cmake templates

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ flake8-copyright = "*"
 mypy = ">=0.500"
 pytest = "*"
 pytest-cov = "*"
+pyfakefs = "*"
 wheel = "*"
 mbed-build = {editable = true, path = "."}
 mbed-tools-ci-scripts = "*"

--- a/mbed_build/_internal/cmake_renderer.py
+++ b/mbed_build/_internal/cmake_renderer.py
@@ -10,19 +10,6 @@ TEMPLATES_DIRECTORY = pathlib.Path("_internal", "templates")
 TEMPLATE_NAME = "CMakeLists.tmpl"
 
 
-def _render_cmakelists_template() -> str:
-    """Loads the CMakeLists.txt file template and renders it with the correct details.
-
-    Returns:
-        The contents of the rendered CMakeLists.txt template.
-    """
-
-    env = jinja2.Environment(loader=jinja2.PackageLoader("mbed_build", str(TEMPLATES_DIRECTORY)),)
-    template = env.get_template(TEMPLATE_NAME)
-    context = {"hello": "Hello", "world": "World"}
-    return template.render(context)
-
-
 def write_cmakelists_file(output_directory: str) -> None:
     """Writes out the CMakeLists.txt file to the output directory.
 
@@ -41,3 +28,16 @@ def write_cmakelists_file(output_directory: str) -> None:
 
     output_file = export_directory.joinpath("CMakeLists.txt")
     output_file.write_text(_render_cmakelists_template())
+
+
+def _render_cmakelists_template() -> str:
+    """Loads the CMakeLists.txt file template and renders it with the correct details.
+
+    Returns:
+        The contents of the rendered CMakeLists.txt template.
+    """
+
+    env = jinja2.Environment(loader=jinja2.PackageLoader("mbed_build", str(TEMPLATES_DIRECTORY)),)
+    template = env.get_template(TEMPLATE_NAME)
+    context = {"hello": "Hello", "world": "World"}
+    return template.render(context)

--- a/mbed_build/_internal/cmake_renderer.py
+++ b/mbed_build/_internal/cmake_renderer.py
@@ -1,5 +1,6 @@
-import jinja2
 import pathlib
+
+import jinja2
 
 TEMPLATES_DIRECTORY = pathlib.Path("_internal", "templates")
 TEMPLATE_NAME = "CMakeLists.tmpl"

--- a/mbed_build/_internal/cmake_renderer.py
+++ b/mbed_build/_internal/cmake_renderer.py
@@ -1,0 +1,38 @@
+import jinja2
+import pathlib
+
+TEMPLATES_DIRECTORY = pathlib.Path("_internal", "templates")
+TEMPLATE_NAME = "CMakeLists.tmpl"
+
+
+def _render_cmakelists_template() -> str:
+    """Loads the CMakeLists.txt file template and renders it with the correct details.
+
+    Returns:
+        The contents of the rendered CMakeLists.txt template.
+    """
+
+    env = jinja2.Environment(loader=jinja2.PackageLoader("mbed_build", str(TEMPLATES_DIRECTORY)),)
+    template = env.get_template(TEMPLATE_NAME)
+    context = {"hello": "Hello", "world": "World"}
+    return template.render(context)
+
+
+def write_cmakelists_file(output_directory: str) -> None:
+    """Writes out the CMakeLists.txt file to the output directory.
+
+    If the intermediate directories to the output directory don't exist,
+    this function will create them.
+
+    This function will overwrite any existing CMakeLists.txt file in the
+    output directory.
+
+    Args:
+        output_directory: path to directory where we want the CMakeLists.txt to go
+    """
+
+    export_directory = pathlib.Path(output_directory)
+    export_directory.mkdir(parents=True, exist_ok=True)
+
+    output_file = export_directory.joinpath("CMakeLists.txt")
+    output_file.write_text(_render_cmakelists_template())

--- a/mbed_build/_internal/cmake_renderer.py
+++ b/mbed_build/_internal/cmake_renderer.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 import pathlib
 
 import jinja2

--- a/mbed_build/_internal/templates/CMakeLists.tmpl
+++ b/mbed_build/_internal/templates/CMakeLists.tmpl
@@ -1,0 +1,1 @@
+{{ hello }} {{ world }}

--- a/news/20200325.feature
+++ b/news/20200325.feature
@@ -1,0 +1,1 @@
+Add functionality for rendering and outputting CMakeLists.txt file.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     description="Core Build Tools for Mbed OS",
     keywords="Arm Mbed OS MbedOS Arm Mbed OS MbedOS build compile link cmake",
     include_package_data=True,
-    install_requires=["python-dotenv", "Click==7.0"],
+    install_requires=["python-dotenv", "Click==7.0", "Jinja2"],
     license="Apache 2.0",
     long_description_content_type="text/markdown",
     long_description=long_description,

--- a/tests/test_cmake_renderer.py
+++ b/tests/test_cmake_renderer.py
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+import pathlib
+from pyfakefs.fake_filesystem_unittest import Patcher
+from unittest import TestCase, mock
+from mbed_build._internal.cmake_renderer import _render_cmakelists_template, write_cmakelists_file
+
+
+class TestWriteCMakeListsFile(TestCase):
+    @mock.patch("mbed_build._internal.cmake_renderer._render_cmakelists_template")
+    def test_writes_content_to_file(self, _render_cmakelists_template):
+        with Patcher():
+            content = "Some rendered content"
+            _render_cmakelists_template.return_value = content
+            export_path = pathlib.Path("tests", "output")
+
+            write_cmakelists_file(str(export_path))
+
+            created_file = pathlib.Path(export_path, "CMakeLists.txt")
+            self.assertTrue(created_file.is_file())
+            self.assertEqual(created_file.read_text(), content)
+
+
+class TestRendersCMakeListsFile(TestCase):
+    def test_returns_rendered_content(self):
+        result = _render_cmakelists_template()
+
+        self.assertEqual(result, "Hello World")

--- a/tests/test_cmake_renderer.py
+++ b/tests/test_cmake_renderer.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib
-from pyfakefs.fake_filesystem_unittest import Patcher
 from unittest import TestCase, mock
+
+from pyfakefs.fake_filesystem_unittest import Patcher
+
 from mbed_build._internal.cmake_renderer import _render_cmakelists_template, write_cmakelists_file
 
 


### PR DESCRIPTION
### Description

Add initial functionality for rendering and outputting a top-level CMakeLists.txt file. 

In the spirit of small PRs I have kept this very simple to start will but it will change over the next PRs.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
