### PR TITLE
✨ mbed_lib.json discovery (part 2)

### DIFF
--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -28,11 +28,12 @@ def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> Iterable
     Returns:
         List of paths.
     """
+    result = list(paths)
     mbedignore_paths = find_files(".mbedignore", directory)
     for mbedignore_path in mbedignore_paths:
         patterns = _build_mbedignore_patterns(mbedignore_path)
-        paths = (path for path in paths if not _matches_mbedignore_patterns(path, patterns))
-    return paths
+        result = [path for path in result if not _matches_mbedignore_patterns(path, patterns)]
+    return result
 
 
 def exclude_using_target_labels(mbed_program_directory: Path, board_type: str, paths: Iterable[Path]) -> Iterable[Path]:
@@ -44,10 +45,11 @@ def exclude_using_target_labels(mbed_program_directory: Path, board_type: str, p
         paths: Paths to filter.
     """
     build_attributes = get_build_attributes_by_board_type(board_type, mbed_program_directory)
-    paths = exclude_using_labels("TARGET", build_attributes.labels, paths)
-    paths = exclude_using_labels("FEATURE", build_attributes.features, paths)
-    paths = exclude_using_labels("COMPONENT", build_attributes.components, paths)
-    return paths
+    result = list(paths)
+    result = exclude_using_labels("TARGET", build_attributes.labels, result)
+    result = exclude_using_labels("FEATURE", build_attributes.features, result)
+    result = exclude_using_labels("COMPONENT", build_attributes.components, result)
+    return result
 
 
 def exclude_using_labels(label_type: str, allowed_label_values: Iterable[str], paths: Iterable[Path]) -> Iterable[Path]:
@@ -64,7 +66,7 @@ def exclude_using_labels(label_type: str, allowed_label_values: Iterable[str], p
         allowed_label_values: Labels which are allowed for given type.
         paths: Paths to filter.
     """
-    return (path for path in paths if _matches_label_rules(path, label_type, set(allowed_label_values)))
+    return [path for path in paths if _matches_label_rules(path, label_type, set(allowed_label_values))]
 
 
 def _build_mbedignore_patterns(mbedignore_path: Path) -> Iterable[str]:

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -28,12 +28,11 @@ def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> Iterable
     Returns:
         List of paths.
     """
-    local_paths = paths[:]
     mbedignore_paths = find_files(".mbedignore", directory)
     for mbedignore_path in mbedignore_paths:
         patterns = _build_mbedignore_patterns(mbedignore_path)
-        local_paths = [path for path in paths if not _matches_mbedignore_patterns(path, patterns)]
-    return local_paths
+        paths = (path for path in paths if not _matches_mbedignore_patterns(path, patterns))
+    return paths
 
 
 def exclude_using_target_labels(mbed_program_directory, board_type, paths):

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -36,7 +36,13 @@ def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> Iterable
 
 
 def exclude_using_target_labels(mbed_program_directory: Path, board_type: str, paths: Iterable[Path]) -> Iterable[Path]:
-    """Filter out given paths using target labels."""
+    """Filter out given paths using target labels retrieved from mbed-targets.
+
+    Args:
+        mbed_program_directory: Path to mbed program, used by mbed-targets to retrieve target build attributes.
+        board_type: Board type, used by mbed-targets to retrieve target build attributes.
+        paths: Paths to filter.
+    """
     build_attributes = get_build_attributes_by_board_type(board_type, mbed_program_directory)
     paths = exclude_using_labels("TARGET", build_attributes.labels, paths)
     paths = exclude_using_labels("FEATURE", build_attributes.features, paths)

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -64,13 +64,7 @@ def exclude_using_labels(label_type: str, allowed_label_values: Iterable[str], p
          allowed_label_values: Labels which are allowed for given type.
          paths: Paths to filter.
      """
-    result = []
-    allowed_values = set(allowed_label_values)
-    for path in paths:
-        label_values = set(_extract_label_values(path, label_type))
-        if label_values.issubset(allowed_values):
-            result.append(path)
-    return result
+    return (path for path in paths if _matches_label_rules(path, label_type, set(allowed_label_values)))
 
 
 def _build_mbedignore_patterns(mbedignore_path: Path) -> Iterable[str]:
@@ -95,6 +89,7 @@ def _matches_mbedignore_patterns(path: Path, patterns: Iterable[str]) -> bool:
     return any(fnmatch(stringified, pattern) for pattern in patterns)
 
 
-def _extract_label_values(path: Path, label_type: str) -> Iterable[str]:
-    """Find label values of given type in path."""
-    return (part for part in path.parts if label_type in part)
+def _matches_label_rules(path: Path, label_type: str, allowed_label_values: set) -> bool:
+    """Check if given path contains only allowed values for a given label type."""
+    label_values = set(part for part in path.parts if label_type in part)
+    return label_values.issubset(allowed_label_values)

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -31,6 +31,29 @@ def exclude_using_mbedignore(mbedignore_path: Path, paths: Iterable[Path]) -> It
     return [path for path in paths if not _matches_mbedignore_patterns(path, patterns)]
 
 
+def exclude_not_labelled(label_type: str, allowed_label_values: Iterable[str], paths: Iterable[Path]) -> Iterable[Path]:
+    """Filter out given path objects using path labelling rules.
+
+     If a path is labelled with given type, but contains label value which is
+     not allowed, it will be filtered out.
+
+     An example of labelled path is "/mbed-os/rtos/source/TARGET_CORTEX/mbed_lib.json",
+     where label type is "TARGET" and label value is "CORTEX".
+
+     Args:
+         label_type: Type of label.
+         allowed_label_values: Labels which are allowed for given type.
+         paths: Paths to filter.
+     """
+    result = []
+    allowed_values = set(allowed_label_values)
+    for path in paths:
+        label_values = set(_extract_label_values(path, label_type))
+        if label_values.issubset(allowed_values):
+            result.append(path)
+    return result
+
+
 def _build_mbedignore_patterns(mbedignore_path: Path) -> Iterable[str]:
     """Return patterns extracted from .mbedignore file.
 
@@ -51,3 +74,8 @@ def _matches_mbedignore_patterns(path: Path, patterns: Iterable[str]) -> bool:
     """Check if given path matches one of the .mbedignore patterns."""
     stringified = str(path)
     return any(fnmatch(stringified, pattern) for pattern in patterns)
+
+
+def _extract_label_values(path: Path, label_type: str) -> Iterable[str]:
+    """Find label values of given type in path."""
+    return (part for part in path.parts if label_type in part)

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -6,6 +6,7 @@
 from pathlib import Path
 from fnmatch import fnmatch
 from typing import Iterable
+from mbed_targets import get_build_attributes_by_board_type
 
 
 def find_files(file_name: str, directory: Path) -> Iterable[Path]:
@@ -29,6 +30,15 @@ def exclude_using_mbedignore(mbedignore_path: Path, paths: Iterable[Path]) -> It
     """
     patterns = _build_mbedignore_patterns(mbedignore_path)
     return [path for path in paths if not _matches_mbedignore_patterns(path, patterns)]
+
+
+def exclude_using_target_labels(mbed_program_directory, board_type, paths):
+    """Filter out given paths using target labels."""
+    build_attributes = get_build_attributes_by_board_type(board_type, mbed_program_directory)
+    paths = exclude_using_labels("TARGET", build_attributes.labels, paths)
+    paths = exclude_using_labels("FEATURE", build_attributes.features, paths)
+    paths = exclude_using_labels("COMPONENT", build_attributes.components, paths)
+    return paths
 
 
 def exclude_using_labels(label_type: str, allowed_label_values: Iterable[str], paths: Iterable[Path]) -> Iterable[Path]:

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -31,7 +31,7 @@ def exclude_using_mbedignore(mbedignore_path: Path, paths: Iterable[Path]) -> It
     return [path for path in paths if not _matches_mbedignore_patterns(path, patterns)]
 
 
-def exclude_not_labelled(label_type: str, allowed_label_values: Iterable[str], paths: Iterable[Path]) -> Iterable[Path]:
+def exclude_using_labels(label_type: str, allowed_label_values: Iterable[str], paths: Iterable[Path]) -> Iterable[Path]:
     """Filter out given path objects using path labelling rules.
 
      If a path is labelled with given type, but contains label value which is

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -53,17 +53,17 @@ def exclude_using_target_labels(mbed_program_directory: Path, board_type: str, p
 def exclude_using_labels(label_type: str, allowed_label_values: Iterable[str], paths: Iterable[Path]) -> Iterable[Path]:
     """Filter out given path objects using path labelling rules.
 
-     If a path is labelled with given type, but contains label value which is
-     not allowed, it will be filtered out.
+    If a path is labelled with given type, but contains label value which is
+    not allowed, it will be filtered out.
 
-     An example of labelled path is "/mbed-os/rtos/source/TARGET_CORTEX/mbed_lib.json",
-     where label type is "TARGET" and label value is "CORTEX".
+    An example of labelled path is "/mbed-os/rtos/source/TARGET_CORTEX/mbed_lib.json",
+    where label type is "TARGET" and label value is "CORTEX".
 
-     Args:
-         label_type: Type of label.
-         allowed_label_values: Labels which are allowed for given type.
-         paths: Paths to filter.
-     """
+    Args:
+        label_type: Type of label.
+        allowed_label_values: Labels which are allowed for given type.
+        paths: Paths to filter.
+    """
     return (path for path in paths if _matches_label_rules(path, label_type, set(allowed_label_values)))
 
 

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -5,7 +5,7 @@
 """File scanner."""
 from pathlib import Path
 from fnmatch import fnmatch
-from typing import Iterable
+from typing import Iterable, List
 from mbed_targets import get_build_attributes_by_board_type
 
 
@@ -14,7 +14,7 @@ def find_files(file_name: str, directory: Path) -> Iterable[Path]:
     return directory.rglob(file_name)
 
 
-def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> Iterable[Path]:
+def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> List[Path]:
     """Filter out given paths based on rules found in .mbedignore files.
 
     Patterns in .mbedignore use unix shell-style wildcards (fnmatch). It means
@@ -36,7 +36,7 @@ def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> Iterable
     return result
 
 
-def exclude_using_target_labels(mbed_program_directory: Path, board_type: str, paths: Iterable[Path]) -> Iterable[Path]:
+def exclude_using_target_labels(mbed_program_directory: Path, board_type: str, paths: Iterable[Path]) -> List[Path]:
     """Filter out given paths using target labels retrieved from mbed-targets.
 
     Args:
@@ -52,7 +52,7 @@ def exclude_using_target_labels(mbed_program_directory: Path, board_type: str, p
     return result
 
 
-def exclude_using_labels(label_type: str, allowed_label_values: Iterable[str], paths: Iterable[Path]) -> Iterable[Path]:
+def exclude_using_labels(label_type: str, allowed_label_values: Iterable[str], paths: Iterable[Path]) -> List[Path]:
     """Filter out given path objects using path labelling rules.
 
     If a path is labelled with given type, but contains label value which is

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -35,7 +35,7 @@ def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> Iterable
     return paths
 
 
-def exclude_using_target_labels(mbed_program_directory, board_type, paths):
+def exclude_using_target_labels(mbed_program_directory: Path, board_type: str, paths: Iterable[Path]) -> Iterable[Path]:
     """Filter out given paths using target labels."""
     build_attributes = get_build_attributes_by_board_type(board_type, mbed_program_directory)
     paths = exclude_using_labels("TARGET", build_attributes.labels, paths)

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -91,5 +91,6 @@ def _matches_mbedignore_patterns(path: Path, patterns: Iterable[str]) -> bool:
 
 def _matches_label_rules(path: Path, label_type: str, allowed_label_values: set) -> bool:
     """Check if given path contains only allowed values for a given label type."""
+    allowed_label_values = set(f"{label_type}_{label_value}" for label_value in allowed_label_values)
     label_values = set(part for part in path.parts if label_type in part)
     return label_values.issubset(allowed_label_values)

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -14,8 +14,8 @@ def find_files(file_name: str, directory: Path) -> Iterable[Path]:
     return directory.rglob(file_name)
 
 
-def exclude_using_mbedignore(mbedignore_path: Path, paths: Iterable[Path]) -> Iterable[Path]:
-    """Filter out given paths based on rules found in .mbedignore file.
+def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> Iterable[Path]:
+    """Filter out given paths based on rules found in .mbedignore files.
 
     Patterns in .mbedignore use unix shell-style wildcards (fnmatch). It means
     that functionality, although similar is different to that found in
@@ -28,8 +28,12 @@ def exclude_using_mbedignore(mbedignore_path: Path, paths: Iterable[Path]) -> It
     Returns:
         List of paths.
     """
-    patterns = _build_mbedignore_patterns(mbedignore_path)
-    return [path for path in paths if not _matches_mbedignore_patterns(path, patterns)]
+    local_paths = paths[:]
+    mbedignore_paths = find_files(".mbedignore", directory)
+    for mbedignore_path in mbedignore_paths:
+        patterns = _build_mbedignore_patterns(mbedignore_path)
+        local_paths = [path for path in paths if not _matches_mbedignore_patterns(path, patterns)]
+    return local_paths
 
 
 def exclude_using_target_labels(mbed_program_directory, board_type, paths):

--- a/mbed_build/_internal/mbed_lib.py
+++ b/mbed_build/_internal/mbed_lib.py
@@ -6,6 +6,8 @@
 from pathlib import Path
 from typing import Dict, Iterable
 
+from mbed_targets import get_build_attributes_by_board_type
+
 from mbed_build._internal.find_files import (
     find_files,
     exclude_using_mbedignore,
@@ -31,13 +33,17 @@ def find_mbed_lib_files(mbed_program_directory: Path, board_type: str) -> Iterab
         mbed_lib_paths = exclude_using_mbedignore(mbedignore_path, mbed_lib_paths)
 
     target_labels = _get_all_target_labels(mbed_program_directory, board_type)
-    if target_labels:
-        for label_type, allowed_label_values in target_labels.items():
-            mbed_lib_paths = exclude_not_labelled(label_type, allowed_label_values, mbed_lib_paths)
+    for label_type, allowed_label_values in target_labels.items():
+        mbed_lib_paths = exclude_not_labelled(label_type, allowed_label_values, mbed_lib_paths)
 
     return mbed_lib_paths
 
 
 def _get_all_target_labels(mbed_program_directory: Path, board_type: str) -> Dict:
-    """TODO."""
-    pass
+    """Return all labels for a given target, grouped by type."""
+    build_attributes = get_build_attributes_by_board_type(board_type, mbed_program_directory)
+    return {
+        "TARGET": build_attributes.labels,
+        "FEATURE": build_attributes.features,
+        "COMPONENT": build_attributes.components,
+    }

--- a/mbed_build/_internal/mbed_lib.py
+++ b/mbed_build/_internal/mbed_lib.py
@@ -6,12 +6,10 @@
 from pathlib import Path
 from typing import Iterable
 
-from mbed_targets import get_build_attributes_by_board_type
-
 from mbed_build._internal.find_files import (
     find_files,
     exclude_using_mbedignore,
-    exclude_using_labels,
+    exclude_using_target_labels,
 )
 
 
@@ -24,14 +22,5 @@ def find_mbed_lib_files(mbed_program_directory: Path, board_type: str) -> Iterab
     """
     mbed_lib_paths = find_files("mbed_lib.json", mbed_program_directory)
     mbed_lib_paths = exclude_using_mbedignore(mbed_program_directory, mbed_lib_paths)
-    mbed_lib_paths = _exclude_using_target_labels(mbed_program_directory, board_type, mbed_lib_paths)
+    mbed_lib_paths = exclude_using_target_labels(mbed_program_directory, board_type, mbed_lib_paths)
     return mbed_lib_paths
-
-
-def _exclude_using_target_labels(mbed_program_directory, board_type, paths):
-    """Filter out given paths using target labels."""
-    build_attributes = get_build_attributes_by_board_type(board_type, mbed_program_directory)
-    paths = exclude_using_labels("TARGET", build_attributes.labels, paths)
-    paths = exclude_using_labels("FEATURE", build_attributes.features, paths)
-    paths = exclude_using_labels("COMPONENT", build_attributes.components, paths)
-    return paths

--- a/mbed_build/_internal/mbed_lib.py
+++ b/mbed_build/_internal/mbed_lib.py
@@ -4,17 +4,40 @@
 #
 """Mbed lib file scanner."""
 from pathlib import Path
-from typing import Iterable
+from typing import Dict, Iterable
 
-from mbed_build._internal.find_files import find_files, exclude_using_mbedignore
+from mbed_build._internal.find_files import (
+    find_files,
+    exclude_using_mbedignore,
+    exclude_not_labelled,
+)
 
 
-def find_mbed_lib_files(directory: Path) -> Iterable[Path]:
-    """Finds all mbed lib files."""
-    mbed_lib_paths = find_files("mbed_lib.json", directory)
+def find_mbed_lib_files(mbed_program_directory: Path, board_type: str) -> Iterable[Path]:
+    """Return paths to all mbed_lib.json for a given target.
 
-    mbedignore_paths = find_files(".mbedignore", directory)
+    When discovering mbed_lib.json files, the following filtering is applied:
+    - paths matching patterns from .mbedignore files will be excluded
+    - paths not matching target labels will be excluded
+
+    Args:
+        mbed_program_directory: Location of mbed program
+        board_type: Name of the target to filter files for
+    """
+    mbed_lib_paths = find_files("mbed_lib.json", mbed_program_directory)
+
+    mbedignore_paths = find_files(".mbedignore", mbed_program_directory)
     for mbedignore_path in mbedignore_paths:
         mbed_lib_paths = exclude_using_mbedignore(mbedignore_path, mbed_lib_paths)
 
+    target_labels = _get_all_target_labels(mbed_program_directory, board_type)
+    if target_labels:
+        for label_type, allowed_label_values in target_labels.items():
+            mbed_lib_paths = exclude_not_labelled(label_type, allowed_label_values, mbed_lib_paths)
+
     return mbed_lib_paths
+
+
+def _get_all_target_labels(mbed_program_directory: Path, board_type: str) -> Dict:
+    """TODO."""
+    pass

--- a/mbed_build/_internal/mbed_lib.py
+++ b/mbed_build/_internal/mbed_lib.py
@@ -4,46 +4,34 @@
 #
 """Mbed lib file scanner."""
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Iterable
 
 from mbed_targets import get_build_attributes_by_board_type
 
 from mbed_build._internal.find_files import (
     find_files,
     exclude_using_mbedignore,
-    exclude_not_labelled,
+    exclude_using_labels,
 )
 
 
 def find_mbed_lib_files(mbed_program_directory: Path, board_type: str) -> Iterable[Path]:
     """Return paths to all mbed_lib.json for a given target.
 
-    When discovering mbed_lib.json files, the following filtering is applied:
-    - paths matching patterns from .mbedignore files will be excluded
-    - paths not matching target labels will be excluded
-
     Args:
         mbed_program_directory: Location of mbed program
         board_type: Name of the target to filter files for
     """
     mbed_lib_paths = find_files("mbed_lib.json", mbed_program_directory)
-
-    mbedignore_paths = find_files(".mbedignore", mbed_program_directory)
-    for mbedignore_path in mbedignore_paths:
-        mbed_lib_paths = exclude_using_mbedignore(mbedignore_path, mbed_lib_paths)
-
-    target_labels = _get_all_target_labels(mbed_program_directory, board_type)
-    for label_type, allowed_label_values in target_labels.items():
-        mbed_lib_paths = exclude_not_labelled(label_type, allowed_label_values, mbed_lib_paths)
-
+    mbed_lib_paths = exclude_using_mbedignore(mbed_program_directory, mbed_lib_paths)
+    mbed_lib_paths = _exclude_using_target_labels(mbed_program_directory, board_type, mbed_lib_paths)
     return mbed_lib_paths
 
 
-def _get_all_target_labels(mbed_program_directory: Path, board_type: str) -> Dict:
-    """Return all labels for a given target, grouped by type."""
+def _exclude_using_target_labels(mbed_program_directory, board_type, paths):
+    """Filter out given paths using target labels."""
     build_attributes = get_build_attributes_by_board_type(board_type, mbed_program_directory)
-    return {
-        "TARGET": build_attributes.labels,
-        "FEATURE": build_attributes.features,
-        "COMPONENT": build_attributes.components,
-    }
+    paths = exclude_using_labels("TARGET", build_attributes.labels, paths)
+    paths = exclude_using_labels("FEATURE", build_attributes.features, paths)
+    paths = exclude_using_labels("COMPONENT", build_attributes.components, paths)
+    return paths

--- a/news/20200402.feature
+++ b/news/20200402.feature
@@ -1,0 +1,1 @@
+Filter mbed_lib.json files by target labels

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -35,6 +35,7 @@ class TestFindFiles(TestCase):
 class TestExcludeUsingMbedignore(TestCase):
     @patchfs
     def test_excludes_files_ignored_by_mbedignore(self, fs):
+        project_path = Path("project")
         mbedignore_contents = """
 *.py
 hidden.txt
@@ -43,7 +44,7 @@ hidden.txt
 */stubs/*
 stubs/*
 """
-        mbedignore_path = Path("project", ".mbedignore")
+        mbedignore_path = project_path.joinpath(".mbedignore")
         fs.create_file(mbedignore_path, contents=mbedignore_contents)
 
         paths = [
@@ -60,7 +61,7 @@ stubs/*
             Path("project", "file.py"),
         ]
 
-        subject = exclude_using_mbedignore(mbedignore_path, paths + excluded_paths)
+        subject = exclude_using_mbedignore(project_path, paths + excluded_paths)
 
         for path in subject:
             self.assertIn(path, paths, f"{path} should be excluded")

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -66,7 +66,6 @@ stubs/*
 
 class TestExcludeUsingLabels(TestCase):
     def test_excludes_files_not_matching_label(self):
-
         paths = [
             Path("mbed-os", "TARGET_BAR", "some_file.c"),
             Path("mbed-os", "COMPONENT_X", "header.h"),

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -9,7 +9,7 @@ from pyfakefs.fake_filesystem_unittest import patchfs
 from mbed_build._internal.find_files import (
     find_files,
     exclude_using_mbedignore,
-    exclude_not_labelled,
+    exclude_using_labels,
 )
 
 
@@ -64,7 +64,7 @@ stubs/*
             self.assertIn(path, paths, f"{path} should be excluded")
 
 
-class TestExcludeNotLabelled(TestCase):
+class TestExcludeUsingLabels(TestCase):
     def test_excludes_files_not_matching_label(self):
 
         paths = [
@@ -80,7 +80,7 @@ class TestExcludeNotLabelled(TestCase):
             Path("mbed-os", "TARGET_BAR", "TARGET_FOO", "other_file.c"),
         ]
 
-        subject = exclude_not_labelled(
+        subject = exclude_using_labels(
             label_type="TARGET", allowed_label_values=["BAR", "BAZ"], paths=(paths + excluded_paths)
         )
 

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -18,18 +18,17 @@ from mbed_build._internal.find_files import (
 class TestFindFiles(TestCase):
     @patchfs
     def test_finds_files_by_name_in_given_root(self, fs):
-        files = (
+        files = [
             Path("root", "folder_1", "file.txt"),
             Path("root", "folder_1", "folder_1_1", "file.txt"),
             Path("root", "folder_2", "file.txt"),
-        )
+        ]
         for file in files:
             fs.create_file(file)
 
         subject = find_files("file.txt", directory=Path("root"))
 
-        for file in files:
-            self.assertIn(file, subject)
+        self.assertEqual(list(subject), files)
 
 
 class TestExcludeUsingMbedignore(TestCase):
@@ -63,8 +62,7 @@ stubs/*
 
         subject = exclude_using_mbedignore(project_path, paths + excluded_paths)
 
-        for path in subject:
-            self.assertIn(path, paths, f"{path} should be excluded")
+        self.assertEqual(list(subject), paths)
 
 
 class TestExcludeUsingTargetLabels(TestCase):
@@ -116,5 +114,4 @@ class TestExcludeUsingLabels(TestCase):
             label_type="TARGET", allowed_label_values=["BAR", "BAZ"], paths=(paths + excluded_paths)
         )
 
-        for path in subject:
-            self.assertIn(path, paths, f"{path} should be excluded")
+        self.assertEqual(list(subject), paths)

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -111,7 +111,7 @@ class TestExcludeUsingLabels(TestCase):
         ]
 
         subject = exclude_using_labels(
-            label_type="TARGET", allowed_label_values=["BAR", "BAZ"], paths=(paths + excluded_paths)
+            label_type="TARGET", allowed_label_values={"BAR", "BAZ"}, paths=(paths + excluded_paths)
         )
 
         self.assertEqual(list(subject), paths)

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -30,7 +30,7 @@ class TestFindFiles(TestCase):
             self.assertIn(file, subject)
 
 
-class TestExcludeListedInMbedignore(TestCase):
+class TestExcludeUsingMbedignore(TestCase):
     @patchfs
     def test_excludes_files_ignored_by_mbedignore(self, fs):
         mbedignore_contents = """

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -9,6 +9,7 @@ from pyfakefs.fake_filesystem_unittest import patchfs
 from mbed_build._internal.find_files import (
     find_files,
     exclude_using_mbedignore,
+    exclude_not_labelled,
 )
 
 
@@ -58,6 +59,30 @@ stubs/*
         ]
 
         subject = exclude_using_mbedignore(mbedignore_path, paths + excluded_paths)
+
+        for path in subject:
+            self.assertIn(path, paths, f"{path} should be excluded")
+
+
+class TestExcludeNotLabelled(TestCase):
+    def test_excludes_files_not_matching_label(self):
+
+        paths = [
+            Path("mbed-os", "TARGET_BAR", "some_file.c"),
+            Path("mbed-os", "COMPONENT_X", "header.h"),
+            Path("mbed-os", "COMPONENT_X", "TARGET_BAZ", "some_file.c"),
+            Path("README.md"),
+        ]
+
+        excluded_paths = [
+            Path("mbed-os", "TARGET_FOO", "some_file.c"),
+            Path("mbed-os", "TARGET_FOO", "nested", "other_file.c"),
+            Path("mbed-os", "TARGET_BAR", "TARGET_FOO", "other_file.c"),
+        ]
+
+        subject = exclude_not_labelled(
+            label_type="TARGET", allowed_label_values=["BAR", "BAZ"], paths=(paths + excluded_paths)
+        )
 
         for path in subject:
             self.assertIn(path, paths, f"{path} should be excluded")

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -35,19 +35,17 @@ class TestExcludeUsingMbedignore(TestCase):
     @patchfs
     def test_excludes_files_ignored_by_mbedignore(self, fs):
         project_path = Path("project")
-        mbedignore_contents = """
+        fs.create_file(project_path.joinpath(".mbedignore"), contents="""
 *.py
 hidden.txt
 
 */test/*
 */stubs/*
 stubs/*
-"""
-        mbedignore_path = project_path.joinpath(".mbedignore")
-        fs.create_file(mbedignore_path, contents=mbedignore_contents)
+""")
+        fs.create_file(project_path.joinpath("isolated" , ".mbedignore"), contents="*")
 
         paths = [
-            Path("outside_of_project", "hidden.txt"),
             Path("foo.py"),
             Path("project", "test", "foo.html"),
         ]
@@ -58,6 +56,7 @@ stubs/*
             Path("project", "stubs", "file.xls"),
             Path("project", "hidden.txt"),
             Path("project", "file.py"),
+            Path("project", "isolated", "file.c")
         ]
 
         subject = exclude_using_mbedignore(project_path, paths + excluded_paths)

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -35,15 +35,18 @@ class TestExcludeUsingMbedignore(TestCase):
     @patchfs
     def test_excludes_files_ignored_by_mbedignore(self, fs):
         project_path = Path("project")
-        fs.create_file(project_path.joinpath(".mbedignore"), contents="""
+        fs.create_file(
+            project_path.joinpath(".mbedignore"),
+            contents="""
 *.py
 hidden.txt
 
 */test/*
 */stubs/*
 stubs/*
-""")
-        fs.create_file(project_path.joinpath("isolated" , ".mbedignore"), contents="*")
+""",
+        )
+        fs.create_file(project_path.joinpath("isolated", ".mbedignore"), contents="*")
 
         paths = [
             Path("foo.py"),
@@ -56,7 +59,7 @@ stubs/*
             Path("project", "stubs", "file.xls"),
             Path("project", "hidden.txt"),
             Path("project", "file.py"),
-            Path("project", "isolated", "file.c")
+            Path("project", "isolated", "file.c"),
         ]
 
         subject = exclude_using_mbedignore(project_path, paths + excluded_paths)

--- a/tests/_internal/test_mbed_lib.py
+++ b/tests/_internal/test_mbed_lib.py
@@ -6,12 +6,14 @@ from pathlib import Path
 from pyfakefs.fake_filesystem_unittest import patchfs
 from unittest import TestCase, mock
 
-from mbed_build._internal.mbed_lib import find_mbed_lib_files
+from mbed_build._internal.mbed_lib import find_mbed_lib_files, _get_all_target_labels
+from mbed_targets import MbedTargetBuildAttributes
 
 
 class TestFindMbedLibFiles(TestCase):
     @patchfs
-    def test_finds_all_mbed_lib_files(self, fs):
+    @mock.patch("mbed_build._internal.mbed_lib._get_all_target_labels", return_value={}, autospec=True)
+    def test_finds_all_mbed_lib_files(self, _get_all_target_labels, fs):
         mbed_lib_paths = (
             Path("root", "mbed_lib.json"),
             Path("root", "foo", "mbed_lib.json"),
@@ -26,7 +28,8 @@ class TestFindMbedLibFiles(TestCase):
             self.assertIn(path, subject)
 
     @patchfs
-    def test_respects_mbedignore(self, fs):
+    @mock.patch("mbed_build._internal.mbed_lib._get_all_target_labels", return_value={}, autospec=True)
+    def test_respects_mbedignore(self, _get_all_target_labels, fs):
         mbed_lib_paths = (
             Path("root", "mbed_lib.json"),
             Path("root", "foo", "mbed_lib.json"),
@@ -51,7 +54,7 @@ ignored_2/mbed_lib.json
             self.assertNotIn(path, ignored_mbed_lib_paths, f"{path} should be ignored")
 
     @patchfs
-    @mock.patch("mbed_build._internal.mbed_lib._get_all_target_labels", autospec=True)
+    @mock.patch("mbed_build._internal.mbed_lib._get_all_target_labels", return_value={}, autospec=True)
     def test_respects_labelling_rules(self, _get_all_target_labels, fs):
         mbed_program_directory = Path("not_important")
         board_type = "K64F"
@@ -72,3 +75,26 @@ ignored_2/mbed_lib.json
         for path in subject:
             self.assertNotIn(path, ignored_mbed_lib_paths, f"{path} should be ignored")
         _get_all_target_labels.assert_called_once_with(mbed_program_directory, board_type)
+
+
+class TestGetAllTargetLabels(TestCase):
+    @mock.patch("mbed_build._internal.mbed_lib.get_build_attributes_by_board_type", autospec=True)
+    def test_returns_labels_extracted_from_build_attributes(self, get_build_attributes_by_board_type):
+        build_attributes = mock.Mock(
+            MbedTargetBuildAttributes, labels={"TARGET"}, features={"FEATURE"}, components={"COMPONENT"}
+        )  # Zero interface safety here, dataclasses don't support spec_set
+        get_build_attributes_by_board_type.return_value = build_attributes
+        mbed_program_directory = Path("some-path")
+        board_type = "A_TYPE"
+
+        subject = _get_all_target_labels(mbed_program_directory, board_type)
+
+        self.assertEqual(
+            subject,
+            {
+                "TARGET": build_attributes.labels,
+                "FEATURE": build_attributes.features,
+                "COMPONENT": build_attributes.components,
+            },
+        )
+        get_build_attributes_by_board_type.assert_called_once_with(board_type, mbed_program_directory)

--- a/tests/_internal/test_mbed_lib.py
+++ b/tests/_internal/test_mbed_lib.py
@@ -5,55 +5,24 @@
 from pathlib import Path
 from unittest import TestCase, mock
 
-from mbed_build._internal.mbed_lib import find_mbed_lib_files, _exclude_using_target_labels
-from mbed_targets import MbedTargetBuildAttributes
+from mbed_build._internal.mbed_lib import find_mbed_lib_files
 
 
 class TestFindMbedLibFiles(TestCase):
     @mock.patch("mbed_build._internal.mbed_lib.find_files", autospec=True)
     @mock.patch("mbed_build._internal.mbed_lib.exclude_using_mbedignore", autospec=True)
-    @mock.patch("mbed_build._internal.mbed_lib._exclude_using_target_labels", autospec=True)
+    @mock.patch("mbed_build._internal.mbed_lib.exclude_using_target_labels", autospec=True)
     def test_filters_mbed_lib_json_paths_using_exclusion_rules(
-        self, _exclude_using_target_labels, exclude_using_mbedignore, find_files
+        self, exclude_using_target_labels, exclude_using_mbedignore, find_files
     ):
         mbed_program_directory = Path("some-program")
         board_type = "K64F"
 
         subject = find_mbed_lib_files(mbed_program_directory, board_type)
 
-        self.assertEqual(subject, _exclude_using_target_labels.return_value)
+        self.assertEqual(subject, exclude_using_target_labels.return_value)
         find_files.assert_called_once_with("mbed_lib.json", mbed_program_directory)
         exclude_using_mbedignore.assert_called_once_with(mbed_program_directory, find_files.return_value)
-        _exclude_using_target_labels.assert_called_once_with(
+        exclude_using_target_labels.assert_called_once_with(
             mbed_program_directory, board_type, exclude_using_mbedignore.return_value
-        )
-
-
-class TestExcludeUsingTargetLabels(TestCase):
-    @mock.patch("mbed_build._internal.mbed_lib.get_build_attributes_by_board_type", autospec=True)
-    @mock.patch("mbed_build._internal.mbed_lib.exclude_using_labels", autospec=True)
-    def test_excludes_paths_using_target_labels(self, exclude_using_labels, get_build_attributes_by_board_type):
-        build_attributes = mock.Mock(
-            MbedTargetBuildAttributes, labels={"TARGET"}, features={"FEATURE"}, components={"COMPONENT"}
-        )  # Zero interface safety here, dataclasses don't support spec_set
-        get_build_attributes_by_board_type.return_value = build_attributes
-        after_target_filtering = [Path("filtered_using_targets")]
-        after_feature_filtering = [Path("filtered_using_features")]
-        after_component_filtering = [Path("filtered_using_components")]
-        exclude_using_labels.side_effect = [after_target_filtering, after_feature_filtering, after_component_filtering]
-        mbed_program_directory = Path("some-path")
-        board_type = "A_TYPE"
-        paths = [Path("mbed_lib.json")]
-
-        subject = _exclude_using_target_labels(mbed_program_directory, board_type, paths)
-
-        self.assertEqual(subject, after_component_filtering)
-        get_build_attributes_by_board_type.assert_called_once_with(board_type, mbed_program_directory)
-        self.assertEqual(
-            exclude_using_labels.mock_calls,
-            [
-                mock.call("TARGET", build_attributes.labels, paths),
-                mock.call("FEATURE", build_attributes.features, after_target_filtering),
-                mock.call("COMPONENT", build_attributes.components, after_feature_filtering),
-            ],
         )

--- a/tests/_internal/test_mbed_lib.py
+++ b/tests/_internal/test_mbed_lib.py
@@ -4,7 +4,7 @@
 #
 from pathlib import Path
 from pyfakefs.fake_filesystem_unittest import patchfs
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from mbed_build._internal.mbed_lib import find_mbed_lib_files
 
@@ -20,7 +20,7 @@ class TestFindMbedLibFiles(TestCase):
         for path in mbed_lib_paths:
             fs.create_file(path)
 
-        subject = find_mbed_lib_files(Path("root"))
+        subject = find_mbed_lib_files(Path("root"), board_type="K64F")
 
         for path in mbed_lib_paths:
             self.assertIn(path, subject)
@@ -45,7 +45,30 @@ ignored_2/mbed_lib.json
 """
         fs.create_file(mbedignore_path, contents=mbedignore_contents)
 
-        subject = find_mbed_lib_files(Path("root"))
+        subject = find_mbed_lib_files(Path("root"), board_type="K66F")
 
         for path in subject:
             self.assertNotIn(path, ignored_mbed_lib_paths, f"{path} should be ignored")
+
+    @patchfs
+    @mock.patch("mbed_build._internal.mbed_lib._get_all_target_labels", autospec=True)
+    def test_respects_labelling_rules(self, _get_all_target_labels, fs):
+        mbed_program_directory = Path("not_important")
+        board_type = "K64F"
+        _get_all_target_labels.return_value = {"TARGET": ["FOO", "BAR"]}
+        mbed_lib_paths = (
+            Path("root", "TARGET_FOO", "mbed_lib.json"),
+            Path("root", "TARGET_FOO", "TARGET_BAR", "mbed_lib.json"),
+        )
+        ignored_mbed_lib_paths = (
+            Path("root", "TARGET_IGNORED", "mbed_lib.json"),
+            Path("root", "TARGET_FOO", "TARGET_IGNORED", "mbed_lib.json"),
+        )
+        for path in mbed_lib_paths + ignored_mbed_lib_paths:
+            fs.create_file(path)
+
+        subject = find_mbed_lib_files(mbed_program_directory, board_type)
+
+        for path in subject:
+            self.assertNotIn(path, ignored_mbed_lib_paths, f"{path} should be ignored")
+        _get_all_target_labels.assert_called_once_with(mbed_program_directory, board_type)

--- a/tests/_internal/test_mbed_lib.py
+++ b/tests/_internal/test_mbed_lib.py
@@ -3,98 +3,57 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from pathlib import Path
-from pyfakefs.fake_filesystem_unittest import patchfs
 from unittest import TestCase, mock
 
-from mbed_build._internal.mbed_lib import find_mbed_lib_files, _get_all_target_labels
+from mbed_build._internal.mbed_lib import find_mbed_lib_files, _exclude_using_target_labels
 from mbed_targets import MbedTargetBuildAttributes
 
 
 class TestFindMbedLibFiles(TestCase):
-    @patchfs
-    @mock.patch("mbed_build._internal.mbed_lib._get_all_target_labels", return_value={}, autospec=True)
-    def test_finds_all_mbed_lib_files(self, _get_all_target_labels, fs):
-        mbed_lib_paths = (
-            Path("root", "mbed_lib.json"),
-            Path("root", "foo", "mbed_lib.json"),
-            Path("root", "foo", "bar", "mbed_lib.json"),
-        )
-        for path in mbed_lib_paths:
-            fs.create_file(path)
-
-        subject = find_mbed_lib_files(Path("root"), board_type="K64F")
-
-        for path in mbed_lib_paths:
-            self.assertIn(path, subject)
-
-    @patchfs
-    @mock.patch("mbed_build._internal.mbed_lib._get_all_target_labels", return_value={}, autospec=True)
-    def test_respects_mbedignore(self, _get_all_target_labels, fs):
-        mbed_lib_paths = (
-            Path("root", "mbed_lib.json"),
-            Path("root", "foo", "mbed_lib.json"),
-            Path("root", "foo", "bar", "mbed_lib.json"),
-        )
-        ignored_mbed_lib_paths = (
-            Path("root", "foo", "ignored_1", "mbed_lib.json"),
-            Path("root", "foo", "ignored_2", "mbed_lib.json"),
-        )
-        for path in mbed_lib_paths + ignored_mbed_lib_paths:
-            fs.create_file(path)
-        mbedignore_path = Path("root", "foo", ".mbedignore")
-        mbedignore_contents = """
-ignored_1/*
-ignored_2/mbed_lib.json
-"""
-        fs.create_file(mbedignore_path, contents=mbedignore_contents)
-
-        subject = find_mbed_lib_files(Path("root"), board_type="K66F")
-
-        for path in subject:
-            self.assertNotIn(path, ignored_mbed_lib_paths, f"{path} should be ignored")
-
-    @patchfs
-    @mock.patch("mbed_build._internal.mbed_lib._get_all_target_labels", return_value={}, autospec=True)
-    def test_respects_labelling_rules(self, _get_all_target_labels, fs):
-        mbed_program_directory = Path("not_important")
+    @mock.patch("mbed_build._internal.mbed_lib.find_files", autospec=True)
+    @mock.patch("mbed_build._internal.mbed_lib.exclude_using_mbedignore", autospec=True)
+    @mock.patch("mbed_build._internal.mbed_lib._exclude_using_target_labels", autospec=True)
+    def test_filters_mbed_lib_json_paths_using_exclusion_rules(
+        self, _exclude_using_target_labels, exclude_using_mbedignore, find_files
+    ):
+        mbed_program_directory = Path("some-program")
         board_type = "K64F"
-        _get_all_target_labels.return_value = {"TARGET": ["FOO", "BAR"]}
-        mbed_lib_paths = (
-            Path("root", "TARGET_FOO", "mbed_lib.json"),
-            Path("root", "TARGET_FOO", "TARGET_BAR", "mbed_lib.json"),
-        )
-        ignored_mbed_lib_paths = (
-            Path("root", "TARGET_IGNORED", "mbed_lib.json"),
-            Path("root", "TARGET_FOO", "TARGET_IGNORED", "mbed_lib.json"),
-        )
-        for path in mbed_lib_paths + ignored_mbed_lib_paths:
-            fs.create_file(path)
 
         subject = find_mbed_lib_files(mbed_program_directory, board_type)
 
-        for path in subject:
-            self.assertNotIn(path, ignored_mbed_lib_paths, f"{path} should be ignored")
-        _get_all_target_labels.assert_called_once_with(mbed_program_directory, board_type)
+        self.assertEqual(subject, _exclude_using_target_labels.return_value)
+        find_files.assert_called_once_with("mbed_lib.json", mbed_program_directory)
+        exclude_using_mbedignore.assert_called_once_with(mbed_program_directory, find_files.return_value)
+        _exclude_using_target_labels.assert_called_once_with(
+            mbed_program_directory, board_type, exclude_using_mbedignore.return_value
+        )
 
 
-class TestGetAllTargetLabels(TestCase):
+class TestExcludeUsingTargetLabels(TestCase):
     @mock.patch("mbed_build._internal.mbed_lib.get_build_attributes_by_board_type", autospec=True)
-    def test_returns_labels_extracted_from_build_attributes(self, get_build_attributes_by_board_type):
+    @mock.patch("mbed_build._internal.mbed_lib.exclude_using_labels", autospec=True)
+    def test_excludes_paths_using_target_labels(self, exclude_using_labels, get_build_attributes_by_board_type):
         build_attributes = mock.Mock(
             MbedTargetBuildAttributes, labels={"TARGET"}, features={"FEATURE"}, components={"COMPONENT"}
         )  # Zero interface safety here, dataclasses don't support spec_set
         get_build_attributes_by_board_type.return_value = build_attributes
+        after_target_filtering = [Path("filtered_using_targets")]
+        after_feature_filtering = [Path("filtered_using_features")]
+        after_component_filtering = [Path("filtered_using_components")]
+        exclude_using_labels.side_effect = [after_target_filtering, after_feature_filtering, after_component_filtering]
         mbed_program_directory = Path("some-path")
         board_type = "A_TYPE"
+        paths = [Path("mbed_lib.json")]
 
-        subject = _get_all_target_labels(mbed_program_directory, board_type)
+        subject = _exclude_using_target_labels(mbed_program_directory, board_type, paths)
 
-        self.assertEqual(
-            subject,
-            {
-                "TARGET": build_attributes.labels,
-                "FEATURE": build_attributes.features,
-                "COMPONENT": build_attributes.components,
-            },
-        )
+        self.assertEqual(subject, after_component_filtering)
         get_build_attributes_by_board_type.assert_called_once_with(board_type, mbed_program_directory)
+        self.assertEqual(
+            exclude_using_labels.mock_calls,
+            [
+                mock.call("TARGET", build_attributes.labels, paths),
+                mock.call("FEATURE", build_attributes.features, after_target_filtering),
+                mock.call("COMPONENT", build_attributes.components, after_feature_filtering),
+            ],
+        )


### PR DESCRIPTION
### Description

Filter list of `mbed_lib.json` files using target labelling rules.

- An example of labelled path is `/path/FEATURE_FOO/mbed_lib.json`, where label type is "FEATURE" and label value is "FOO".
- If a path contains label values that are not allowed for a given target, it should be filtered out.
- There's many label types "TOOLCHAIN", "FEATURE", "TARGET" to name a few - this PR only covers target labels: "TARGET", "FEATURE", "COMPONENT"

#### Example

Given a label "FEATURE_FOO"

`/path/FEATURE_FOO/somefile.txt` ✅
`/path/FEATURE_BAZ/somefile.txt` ❌
`/path/FEATURE_FOO/FEATURE_BAR/somefile.txt` ❌


#### Additional stuff

- while performing some e2e tests vs existing tools I've discovered that `.mbedginore` does not work correctly, so fixing a bug as well

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
