### PR TITLE
✨ mbed_lib.json discovery (part 3) - legacy directories

### DIFF
--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -14,6 +14,20 @@ def find_files(file_name: str, directory: Path) -> Iterable[Path]:
     return directory.rglob(file_name)
 
 
+_LEGACY_DIRS = [
+    "TEST",
+    "TEST_APPS",
+]
+
+
+def exclude_legacy_directories(paths: Iterable[Path]) -> List[Path]:
+    """Filter out given paths using legacy directory list.
+
+    WARNING: This should be removed when mbed-os is cleaned up
+    """
+    return [path for path in paths if not any(legacy_dir in str(path) for legacy_dir in _LEGACY_DIRS)]
+
+
 def exclude_using_mbedignore(directory: Path, paths: Iterable[Path]) -> List[Path]:
     """Filter out given paths based on rules found in .mbedignore files.
 

--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -15,7 +15,7 @@ def find_files(file_name: str, directory: Path) -> Iterable[Path]:
 
 
 _LEGACY_DIRS = [
-    "TEST",
+    "TESTS",
     "TEST_APPS",
 ]
 

--- a/mbed_build/_internal/mbed_lib.py
+++ b/mbed_build/_internal/mbed_lib.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 from mbed_build._internal.find_files import (
     find_files,
+    exclude_legacy_directories,
     exclude_using_mbedignore,
     exclude_using_target_labels,
 )
@@ -21,6 +22,7 @@ def find_mbed_lib_files(mbed_program_directory: Path, board_type: str) -> Iterab
         board_type: Name of the target to filter files for
     """
     mbed_lib_paths = find_files("mbed_lib.json", mbed_program_directory)
+    mbed_lib_paths = exclude_legacy_directories(mbed_lib_paths)  # Should be cleaned in mbed-os source in the future
     mbed_lib_paths = exclude_using_mbedignore(mbed_program_directory, mbed_lib_paths)
     mbed_lib_paths = exclude_using_target_labels(mbed_program_directory, board_type, mbed_lib_paths)
     return mbed_lib_paths

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -9,6 +9,7 @@ from mbed_targets import MbedTargetBuildAttributes
 
 from mbed_build._internal.find_files import (
     find_files,
+    exclude_legacy_directories,
     exclude_using_mbedignore,
     exclude_using_target_labels,
     exclude_using_labels,
@@ -63,6 +64,22 @@ stubs/*
         ]
 
         subject = exclude_using_mbedignore(project_path, paths + excluded_paths)
+
+        self.assertEqual(list(subject), paths)
+
+
+class TestExcludeLegacyDirectories(TestCase):
+    def test_excludes_known_legacy_directories(self):
+        paths = [
+            Path("mbed-os", "subdir", "some_file.c"),
+        ]
+
+        ignored_paths = [
+            Path("mbed-os", "TESTS", "some_file.c"),
+            Path("mbed-os", "TEST_APPS", "some_file.c"),
+        ]
+
+        subject = exclude_legacy_directories(paths + ignored_paths)
 
         self.assertEqual(list(subject), paths)
 

--- a/tests/_internal/test_mbed_lib.py
+++ b/tests/_internal/test_mbed_lib.py
@@ -12,8 +12,9 @@ class TestFindMbedLibFiles(TestCase):
     @mock.patch("mbed_build._internal.mbed_lib.find_files", autospec=True)
     @mock.patch("mbed_build._internal.mbed_lib.exclude_using_mbedignore", autospec=True)
     @mock.patch("mbed_build._internal.mbed_lib.exclude_using_target_labels", autospec=True)
+    @mock.patch("mbed_build._internal.mbed_lib.exclude_legacy_directories", autospec=True)
     def test_filters_mbed_lib_json_paths_using_exclusion_rules(
-        self, exclude_using_target_labels, exclude_using_mbedignore, find_files
+        self, exclude_legacy_directories, exclude_using_target_labels, exclude_using_mbedignore, find_files
     ):
         mbed_program_directory = Path("some-program")
         board_type = "K64F"
@@ -22,7 +23,11 @@ class TestFindMbedLibFiles(TestCase):
 
         self.assertEqual(subject, exclude_using_target_labels.return_value)
         find_files.assert_called_once_with("mbed_lib.json", mbed_program_directory)
-        exclude_using_mbedignore.assert_called_once_with(mbed_program_directory, find_files.return_value)
+
+        exclude_legacy_directories.assert_called_once_with(find_files.return_value)
+        exclude_using_mbedignore.assert_called_once_with(
+            mbed_program_directory, exclude_legacy_directories.return_value
+        )
         exclude_using_target_labels.assert_called_once_with(
             mbed_program_directory, board_type, exclude_using_mbedignore.return_value
         )


### PR DESCRIPTION
### Description

Last exclusion that needs to be applied to retrieve a compelete set of `mbed_lib.json` files. I'm a bit conflicted about this. 🤔 

I'd think `mbed-os` should contain top level `.mbedignore` that excludes `TESTS/`.

Full list available here: https://github.com/ARMmbed/mbed-os/blob/master/tools/resources/__init__.py#L50

- running `find` did not yield any `mbed_lib.json` files in anything other than `TESTS`
- I'm including `TEST_APPS` only because it's the only other directory from this list that exists in `mbed-os` codebase
- FWIW `KL25Z` exists under `TESTS/`

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
