### PR TITLE
✨ Add temporary fix for legacy directories from old tools

### DIFF
--- a/mbed_build/_internal/mbed_lib.py
+++ b/mbed_build/_internal/mbed_lib.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from typing import Iterable
 
-from mbed_build._internal.find_files import find_files, BoardLabelFilter
+from mbed_build._internal.find_files import find_files, BoardLabelFilter, MbedignoreFilter
 
 
 def find_mbed_lib_files(mbed_program_directory: Path, board_type: str) -> Iterable[Path]:
@@ -16,4 +16,11 @@ def find_mbed_lib_files(mbed_program_directory: Path, board_type: str) -> Iterab
         mbed_program_directory: Location of mbed program
         board_type: Name of the target to filter files for
     """
-    return find_files("mbed_lib.json", mbed_program_directory, [BoardLabelFilter(board_type, mbed_program_directory)])
+    board_label_filter = BoardLabelFilter(board_type, mbed_program_directory)
+    # Temporary workaround, which replicates hardcoded ignore rules from old tools.
+    # Legacy list of ignored directories is longer, however "TESTS" and
+    # "TEST_APPS" were the only ones that actually exist in the MbedOS source.
+    # Ideally, this should be solved by putting an `.mbedignore` file in the root of MbedOS repo,
+    # similarly to what the code below pretends is happening.
+    legacy_ignore = MbedignoreFilter(("*/TESTS", "*/TEST_APPS"))
+    return find_files("mbed_lib.json", mbed_program_directory, [legacy_ignore, board_label_filter])

--- a/news/20200406.feature
+++ b/news/20200406.feature
@@ -1,0 +1,1 @@
+Ignore legacy directories in MbedOS

--- a/tests/_internal/test_mbed_lib.py
+++ b/tests/_internal/test_mbed_lib.py
@@ -11,12 +11,16 @@ from mbed_build._internal.mbed_lib import find_mbed_lib_files
 class TestFindMbedLibFiles(TestCase):
     @mock.patch("mbed_build._internal.mbed_lib.find_files", autospec=True)
     @mock.patch("mbed_build._internal.mbed_lib.BoardLabelFilter", autospec=True)
-    def test_filters_mbed_lib_json_paths_using_exclusion_rules(self, BoardLabelFilter, find_files):
+    @mock.patch("mbed_build._internal.mbed_lib.MbedignoreFilter", autospec=True)
+    def test_finds_mbed_lib_files_using_appropriate_filters(self, MbedignoreFilter, BoardLabelFilter, find_files):
         mbed_program_directory = Path("some-program")
         board_type = "K64F"
 
         subject = find_mbed_lib_files(mbed_program_directory, board_type)
 
         self.assertEqual(subject, find_files.return_value)
-        find_files.assert_called_once_with("mbed_lib.json", mbed_program_directory, [BoardLabelFilter.return_value])
+        find_files.assert_called_once_with(
+            "mbed_lib.json", mbed_program_directory, [MbedignoreFilter.return_value, BoardLabelFilter.return_value]
+        )
+        MbedignoreFilter.assert_called_once_with(("*/TESTS", "*/TEST_APPS"))
         BoardLabelFilter.assert_called_once_with(board_type, mbed_program_directory)


### PR DESCRIPTION
### Description

Ignore legacy hardcoded directories from old tools when finding `mbed_lib.json` files.

Full list available here: https://github.com/ARMmbed/mbed-os/blob/master/tools/resources/__init__.py#L50

- running find did not yield any mbed_lib.json files in anything other than TESTS
- I'm including TEST_APPS only because it's the only other directory from this list that exists in mbed-os codebase
- FWIW KL25Z exists under TESTS/



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
