### PR TITLE
🐛Correct path name

### DIFF
--- a/mbed_build/_internal/mbed_tools/export.py
+++ b/mbed_build/_internal/mbed_tools/export.py
@@ -26,8 +26,8 @@ from mbed_build.mbed_build import generate_cmakelists_file, write_cmakelists_fil
     help="The toolchain you are using to build your app.",
 )
 @click.option("-m", "--mbed_target", required=True, help="A build target for an Mbed-enabled device, eg. K64F")
-@click.option("-p", "--mbed-os-path", required=True, help="Path to local Mbed OS library")
-def export(output_directory: str, toolchain: str, mbed_target: str, mbed_os_path: str) -> None:
+@click.option("-p", "--project-path", required=True, help="Path to local Mbed project")
+def export(output_directory: str, toolchain: str, mbed_target: str, project_path: str) -> None:
     """Exports a top-level CMakeLists.txt file to the specified directory.
 
     The parameters set in the CMake file will be dependent on the combination of
@@ -38,10 +38,10 @@ def export(output_directory: str, toolchain: str, mbed_target: str, mbed_os_path
         output_directory: where the top-level CMakeLists.txt should be exported to
         toolchain: the toolchain you are using to build your app (eg. GCC, ARM5 etc.)
         mbed_target: the build target you are wanting to run your app (eg. K64F)
-        mbed_os_path: the path to the project's copy of the Mbed OS library
+        project_path: the path to the local Mbed project
 
     Raises:
         InvalidExportOutputDirectory: it's not possible to export to the output directory provided
     """
-    cmake_file_contents = generate_cmakelists_file(mbed_target, mbed_os_path, toolchain)
+    cmake_file_contents = generate_cmakelists_file(mbed_target, project_path, toolchain)
     write_cmakelists_file(pathlib.Path(output_directory), cmake_file_contents)

--- a/mbed_build/mbed_build.py
+++ b/mbed_build/mbed_build.py
@@ -11,18 +11,18 @@ from mbed_build._internal.cmake_file import render_cmakelists_template, write_cm
 from mbed_build.exceptions import InvalidExportOutputDirectory
 
 
-def generate_cmakelists_file(mbed_target: str, mbed_os_path: str, toolchain_name: str) -> str:
+def generate_cmakelists_file(mbed_target: str, project_path: str, toolchain_name: str) -> str:
     """Generate the top-level CMakeLists.txt file containing the correct definitions for a build.
 
     Args:
         mbed_target: the target the application is being built for
-        mbed_os_path: the path to the project's copy of the Mbed OS library
+        project_path: the path to the local Mbed project
         toolchain_name: the toolchain to be used to build the application
 
     Returns:
         A string of rendered contents for the file.
     """
-    target_build_attributes = get_build_attributes_by_board_type(mbed_target, mbed_os_path)
+    target_build_attributes = get_build_attributes_by_board_type(mbed_target, project_path)
     return render_cmakelists_template(
         target_build_attributes.labels,
         target_build_attributes.features,

--- a/news/20200408.bugfix
+++ b/news/20200408.bugfix
@@ -1,0 +1,1 @@
+Correctly name path to project

--- a/tests/_internal/mbed_tools/test_export.py
+++ b/tests/_internal/mbed_tools/test_export.py
@@ -17,15 +17,15 @@ class TestExport(TestCase):
         mock_file_contents = "Hello world"
         mock_generate_cmakelists_file.return_value = mock_file_contents
         output_dir = "some-directory"
-        mbed_os_path = "mbed-os"
+        project_path = "blinky"
         mbed_target = "K64F"
         toolchain = "GCC"
 
         runner = CliRunner()
-        result = runner.invoke(export, ["-o", output_dir, "-t", toolchain, "-m", mbed_target, "-p", mbed_os_path])
+        result = runner.invoke(export, ["-o", output_dir, "-t", toolchain, "-m", mbed_target, "-p", project_path])
 
         self.assertEqual(result.exit_code, 0)
-        mock_generate_cmakelists_file.assert_called_once_with(mbed_target, mbed_os_path, toolchain)
+        mock_generate_cmakelists_file.assert_called_once_with(mbed_target, project_path, toolchain)
         mock_write_cmakelists_file.assert_called_once_with(
             pathlib.Path(output_dir), mock_generate_cmakelists_file.return_value
         )

--- a/tests/test_mbed_build.py
+++ b/tests/test_mbed_build.py
@@ -17,12 +17,12 @@ class TestGenerateCMakeListsFile(TestCase):
         target_build_attributes = mock.Mock()
         get_build_attributes_by_board_type.return_value = target_build_attributes
         mbed_target = "K64F"
-        mbed_os_path = "mbed-os"
+        project_path = "blinky"
         toolchain_name = "GCC"
 
-        generate_cmakelists_file(mbed_target, mbed_os_path, toolchain_name)
+        generate_cmakelists_file(mbed_target, project_path, toolchain_name)
 
-        get_build_attributes_by_board_type.assert_called_once_with(mbed_target, mbed_os_path)
+        get_build_attributes_by_board_type.assert_called_once_with(mbed_target, project_path)
         render_cmakelists_template.assert_called_once_with(
             target_build_attributes.labels,
             target_build_attributes.features,


### PR DESCRIPTION
### Description

mbed-project accesses the targets.json file via project dir not mbed os dir.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
