### PR TITLE
♻️Default project path

### DIFF
--- a/mbed_build/_internal/mbed_tools/export.py
+++ b/mbed_build/_internal/mbed_tools/export.py
@@ -26,7 +26,9 @@ from mbed_build.mbed_build import generate_cmakelists_file, write_cmakelists_fil
     help="The toolchain you are using to build your app.",
 )
 @click.option("-m", "--mbed_target", required=True, help="A build target for an Mbed-enabled device, eg. K64F")
-@click.option("-p", "--project-path", required=True, help="Path to local Mbed project")
+@click.option(
+    "-p", "--project-path", default=".", help="Path to local Mbed project. By default is the current working directory."
+)
 def export(output_directory: str, toolchain: str, mbed_target: str, project_path: str) -> None:
     """Exports a top-level CMakeLists.txt file to the specified directory.
 

--- a/news/20200408.misc
+++ b/news/20200408.misc
@@ -1,0 +1,1 @@
+By default use cwd as project path in export command

--- a/tests/_internal/mbed_tools/test_export.py
+++ b/tests/_internal/mbed_tools/test_export.py
@@ -29,3 +29,21 @@ class TestExport(TestCase):
         mock_write_cmakelists_file.assert_called_once_with(
             pathlib.Path(output_dir), mock_generate_cmakelists_file.return_value
         )
+
+    @mock.patch("mbed_build._internal.mbed_tools.export.generate_cmakelists_file")
+    @mock.patch("mbed_build._internal.mbed_tools.export.write_cmakelists_file")
+    def test_export_default_project_path(self, mock_write_cmakelists_file, mock_generate_cmakelists_file):
+        mock_file_contents = "Hello world"
+        mock_generate_cmakelists_file.return_value = mock_file_contents
+        output_dir = "some-directory"
+        mbed_target = "K64F"
+        toolchain = "GCC"
+
+        runner = CliRunner()
+        result = runner.invoke(export, ["-o", output_dir, "-t", toolchain, "-m", mbed_target])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_generate_cmakelists_file.assert_called_once_with(mbed_target, ".", toolchain)
+        mock_write_cmakelists_file.assert_called_once_with(
+            pathlib.Path(output_dir), mock_generate_cmakelists_file.return_value
+        )


### PR DESCRIPTION
### Description

By default use cwd as project path in export command


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
