### PR TITLE
✨Add user feedback

### DIFF
--- a/mbed_build/_internal/cmake_file.py
+++ b/mbed_build/_internal/cmake_file.py
@@ -37,7 +37,7 @@ def render_cmakelists_template(
     return template.render(context)
 
 
-def write_cmakelists_file(output_directory: pathlib.Path, file_contents: str) -> pathlib.Path:
+def write_cmakelists_file(output_directory: pathlib.Path, file_contents: str) -> None:
     """Writes out the CMakeLists.txt file to the output directory.
 
     If the intermediate directories to the output directory don't exist,
@@ -49,12 +49,7 @@ def write_cmakelists_file(output_directory: pathlib.Path, file_contents: str) ->
     Args:
         output_directory: path to directory where we want the CMakeLists.txt to go
         file_contents: the contents of the CMakeLists.txt file
-
-    Return:
-        Path to the newly created CMakeLists file.
     """
     output_directory.mkdir(parents=True, exist_ok=True)
     output_file = output_directory.joinpath("CMakeLists.txt")
     output_file.write_text(file_contents)
-
-    return output_file

--- a/mbed_build/_internal/cmake_file.py
+++ b/mbed_build/_internal/cmake_file.py
@@ -37,7 +37,7 @@ def render_cmakelists_template(
     return template.render(context)
 
 
-def write_cmakelists_file(output_directory: pathlib.Path, file_contents: str) -> None:
+def write_cmakelists_file(output_directory: pathlib.Path, file_contents: str) -> pathlib.Path:
     """Writes out the CMakeLists.txt file to the output directory.
 
     If the intermediate directories to the output directory don't exist,
@@ -49,7 +49,12 @@ def write_cmakelists_file(output_directory: pathlib.Path, file_contents: str) ->
     Args:
         output_directory: path to directory where we want the CMakeLists.txt to go
         file_contents: the contents of the CMakeLists.txt file
+
+    Return:
+        Path to the newly created CMakeLists file.
     """
     output_directory.mkdir(parents=True, exist_ok=True)
     output_file = output_directory.joinpath("CMakeLists.txt")
     output_file.write_text(file_contents)
+
+    return output_file

--- a/mbed_build/_internal/mbed_tools/export.py
+++ b/mbed_build/_internal/mbed_tools/export.py
@@ -50,8 +50,5 @@ def export(output_directory: str, toolchain: str, mbed_target: str, project_path
         InvalidExportOutputDirectory: it's not possible to export to the output directory provided
     """
     cmake_file_contents = generate_cmakelists_file(mbed_target, project_path, toolchain)
-    cmake_file_path = write_cmakelists_file(pathlib.Path(output_directory), cmake_file_contents)
-    if cmake_file_path.is_file() and cmake_file_path.read_text() == cmake_file_contents:
-        click.echo(
-            f"The program-level CMake file has been successfully exported to directory '{str(output_directory)}'"
-        )
+    write_cmakelists_file(pathlib.Path(output_directory), cmake_file_contents)
+    click.echo(f"The program-level CMake file has been successfully exported to directory '{str(output_directory)}'")

--- a/mbed_build/_internal/mbed_tools/export.py
+++ b/mbed_build/_internal/mbed_tools/export.py
@@ -50,5 +50,8 @@ def export(output_directory: str, toolchain: str, mbed_target: str, project_path
         InvalidExportOutputDirectory: it's not possible to export to the output directory provided
     """
     cmake_file_contents = generate_cmakelists_file(mbed_target, project_path, toolchain)
-    write_cmakelists_file(pathlib.Path(output_directory), cmake_file_contents)
-    click.echo(f"The program-level CMake file has been successfully exported to directory '{str(output_directory)}'")
+    cmake_file_path = write_cmakelists_file(pathlib.Path(output_directory), cmake_file_contents)
+    if cmake_file_path.is_file() and cmake_file_path.read_text() == cmake_file_contents:
+        click.echo(
+            f"The program-level CMake file has been successfully exported to directory '{str(output_directory)}'"
+        )

--- a/mbed_build/_internal/mbed_tools/export.py
+++ b/mbed_build/_internal/mbed_tools/export.py
@@ -27,7 +27,11 @@ from mbed_build.mbed_build import generate_cmakelists_file, write_cmakelists_fil
 )
 @click.option("-m", "--mbed_target", required=True, help="A build target for an Mbed-enabled device, eg. K64F")
 @click.option(
-    "-p", "--project-path", default=".", help="Path to local Mbed project. By default is the current working directory."
+    "-p",
+    "--project-path",
+    type=click.Path(),
+    default=".",
+    help="Path to local Mbed project. By default is the current working directory.",
 )
 def export(output_directory: str, toolchain: str, mbed_target: str, project_path: str) -> None:
     """Exports a top-level CMakeLists.txt file to the specified directory.

--- a/mbed_build/_internal/mbed_tools/export.py
+++ b/mbed_build/_internal/mbed_tools/export.py
@@ -47,4 +47,4 @@ def export(output_directory: str, toolchain: str, mbed_target: str, project_path
     """
     cmake_file_contents = generate_cmakelists_file(mbed_target, project_path, toolchain)
     write_cmakelists_file(pathlib.Path(output_directory), cmake_file_contents)
-    click.echo(f"The program-level CMake file has been exported to f{str(output_directory)}")
+    click.echo(f"The program-level CMake file has been successfully exported to directory '{str(output_directory)}'")

--- a/mbed_build/_internal/mbed_tools/export.py
+++ b/mbed_build/_internal/mbed_tools/export.py
@@ -26,7 +26,9 @@ from mbed_build.mbed_build import generate_cmakelists_file, write_cmakelists_fil
     help="The toolchain you are using to build your app.",
 )
 @click.option("-m", "--mbed_target", required=True, help="A build target for an Mbed-enabled device, eg. K64F")
-@click.option("-p", "--project-path", required=True, help="Path to local Mbed project")
+@click.option(
+    "-p", "--project-path", default=".", help="Path to local Mbed project. By default is the current working directory."
+)
 def export(output_directory: str, toolchain: str, mbed_target: str, project_path: str) -> None:
     """Exports a top-level CMakeLists.txt file to the specified directory.
 
@@ -45,3 +47,4 @@ def export(output_directory: str, toolchain: str, mbed_target: str, project_path
     """
     cmake_file_contents = generate_cmakelists_file(mbed_target, project_path, toolchain)
     write_cmakelists_file(pathlib.Path(output_directory), cmake_file_contents)
+    click.echo(f"The program-level CMake file has been exported to f{str(output_directory)}")

--- a/news/2020040801.misc
+++ b/news/2020040801.misc
@@ -1,0 +1,1 @@
+Give more user feedback during export

--- a/tests/_internal/mbed_tools/test_export.py
+++ b/tests/_internal/mbed_tools/test_export.py
@@ -11,10 +11,9 @@ from mbed_build._internal.mbed_tools.export import export
 
 
 class TestExport(TestCase):
-    @mock.patch("mbed_build._internal.mbed_tools.export.click.echo")
     @mock.patch("mbed_build._internal.mbed_tools.export.generate_cmakelists_file")
     @mock.patch("mbed_build._internal.mbed_tools.export.write_cmakelists_file")
-    def test_export(self, mock_write_cmakelists_file, mock_generate_cmakelists_file, mock_echo):
+    def test_export(self, mock_write_cmakelists_file, mock_generate_cmakelists_file):
         mock_file_contents = "Hello world"
         mock_generate_cmakelists_file.return_value = mock_file_contents
         output_dir = "some-directory"
@@ -26,18 +25,15 @@ class TestExport(TestCase):
         result = runner.invoke(export, ["-o", output_dir, "-t", toolchain, "-m", mbed_target, "-p", project_path])
 
         self.assertEqual(result.exit_code, 0)
+        self.assertIn(output_dir, result.output)
         mock_generate_cmakelists_file.assert_called_once_with(mbed_target, project_path, toolchain)
         mock_write_cmakelists_file.assert_called_once_with(
             pathlib.Path(output_dir), mock_generate_cmakelists_file.return_value
         )
-        mock_echo.assert_called_once_with(
-            f"The program-level CMake file has been successfully exported to directory '{str(output_dir)}'"
-        )
 
-    @mock.patch("mbed_build._internal.mbed_tools.export.click.echo")
     @mock.patch("mbed_build._internal.mbed_tools.export.generate_cmakelists_file")
     @mock.patch("mbed_build._internal.mbed_tools.export.write_cmakelists_file")
-    def test_export_default_project_path(self, mock_write_cmakelists_file, mock_generate_cmakelists_file, mock_echo):
+    def test_export_default_project_path(self, mock_write_cmakelists_file, mock_generate_cmakelists_file):
         mock_file_contents = "Hello world"
         mock_generate_cmakelists_file.return_value = mock_file_contents
         output_dir = "some-directory"
@@ -48,10 +44,8 @@ class TestExport(TestCase):
         result = runner.invoke(export, ["-o", output_dir, "-t", toolchain, "-m", mbed_target])
 
         self.assertEqual(result.exit_code, 0)
+        self.assertIn(output_dir, result.output)
         mock_generate_cmakelists_file.assert_called_once_with(mbed_target, ".", toolchain)
         mock_write_cmakelists_file.assert_called_once_with(
             pathlib.Path(output_dir), mock_generate_cmakelists_file.return_value
-        )
-        mock_echo.assert_called_once_with(
-            f"The program-level CMake file has been successfully exported to directory '{str(output_dir)}'"
         )

--- a/tests/_internal/mbed_tools/test_export.py
+++ b/tests/_internal/mbed_tools/test_export.py
@@ -11,9 +11,10 @@ from mbed_build._internal.mbed_tools.export import export
 
 
 class TestExport(TestCase):
+    @mock.patch("mbed_build._internal.mbed_tools.export.click.echo")
     @mock.patch("mbed_build._internal.mbed_tools.export.generate_cmakelists_file")
     @mock.patch("mbed_build._internal.mbed_tools.export.write_cmakelists_file")
-    def test_export(self, mock_write_cmakelists_file, mock_generate_cmakelists_file):
+    def test_export(self, mock_write_cmakelists_file, mock_generate_cmakelists_file, mock_echo):
         mock_file_contents = "Hello world"
         mock_generate_cmakelists_file.return_value = mock_file_contents
         output_dir = "some-directory"
@@ -29,10 +30,14 @@ class TestExport(TestCase):
         mock_write_cmakelists_file.assert_called_once_with(
             pathlib.Path(output_dir), mock_generate_cmakelists_file.return_value
         )
+        mock_echo.assert_called_once_with(
+            f"The program-level CMake file has been successfully exported to directory '{str(output_dir)}'"
+        )
 
+    @mock.patch("mbed_build._internal.mbed_tools.export.click.echo")
     @mock.patch("mbed_build._internal.mbed_tools.export.generate_cmakelists_file")
     @mock.patch("mbed_build._internal.mbed_tools.export.write_cmakelists_file")
-    def test_export_default_project_path(self, mock_write_cmakelists_file, mock_generate_cmakelists_file):
+    def test_export_default_project_path(self, mock_write_cmakelists_file, mock_generate_cmakelists_file, mock_echo):
         mock_file_contents = "Hello world"
         mock_generate_cmakelists_file.return_value = mock_file_contents
         output_dir = "some-directory"
@@ -46,4 +51,7 @@ class TestExport(TestCase):
         mock_generate_cmakelists_file.assert_called_once_with(mbed_target, ".", toolchain)
         mock_write_cmakelists_file.assert_called_once_with(
             pathlib.Path(output_dir), mock_generate_cmakelists_file.return_value
+        )
+        mock_echo.assert_called_once_with(
+            f"The program-level CMake file has been successfully exported to directory '{str(output_dir)}'"
         )


### PR DESCRIPTION
### Description
Print a message after successful generation of files to give the user more feedback.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
