### PR TITLE
♻️Update targets

### DIFF
--- a/mbed_build/_internal/find_files.py
+++ b/mbed_build/_internal/find_files.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import fnmatch
 from typing import Callable, Iterable, Optional, List, Tuple
 
-from mbed_targets import get_build_attributes_by_board_type
+from mbed_targets import get_target_by_board_type
 
 
 def find_files(filename: str, directory: Path, filters: Optional[List[Callable]] = None) -> List[Path]:
@@ -60,11 +60,11 @@ class BoardLabelFilter:
 
         Allowed label data will be retrieved from `mbed-targets`.
         """
-        build_attributes = get_build_attributes_by_board_type(board_type, mbed_program_directory)
+        target = get_target_by_board_type(board_type, mbed_program_directory)
         self._label_filters = [
-            LabelFilter("TARGET", build_attributes.labels),
-            LabelFilter("FEATURE", build_attributes.features),
-            LabelFilter("COMPONENT", build_attributes.components),
+            LabelFilter("TARGET", target.labels),
+            LabelFilter("FEATURE", target.features),
+            LabelFilter("COMPONENT", target.components),
         ]
 
     def __call__(self, path: Path) -> bool:

--- a/mbed_build/mbed_build.py
+++ b/mbed_build/mbed_build.py
@@ -5,7 +5,7 @@
 """Module to generate application's CMake file."""
 import pathlib
 
-from mbed_targets import get_build_attributes_by_board_type
+from mbed_targets import get_target_by_name
 
 from mbed_build._internal.cmake_file import render_cmakelists_template, write_cmakelists_file
 from mbed_build.exceptions import InvalidExportOutputDirectory
@@ -22,7 +22,7 @@ def generate_cmakelists_file(mbed_target: str, project_path: str, toolchain_name
     Returns:
         A string of rendered contents for the file.
     """
-    target_build_attributes = get_build_attributes_by_board_type(mbed_target, project_path)
+    target_build_attributes = get_target_by_name(mbed_target, project_path)
     return render_cmakelists_template(
         target_build_attributes.labels,
         target_build_attributes.features,

--- a/news/20200414.major
+++ b/news/20200414.major
@@ -1,0 +1,1 @@
+Update code to work with new names of mbed-targets interfaces.

--- a/tests/_internal/test_find_files.py
+++ b/tests/_internal/test_find_files.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase, mock
 from typing import Iterable
 
-from mbed_targets import MbedTargetBuildAttributes
+from mbed_targets import Target
 
 from mbed_build._internal.find_files import find_files, MbedignoreFilter, LabelFilter, BoardLabelFilter
 
@@ -82,13 +82,13 @@ class TestListFiles(TestCase):
             self.assertIn(Path(directory, path), subject)
 
 
-@mock.patch("mbed_build._internal.find_files.get_build_attributes_by_board_type", autospec=True)
+@mock.patch("mbed_build._internal.find_files.get_target_by_board_type", autospec=True)
 class TestBoardLabelFilter(TestCase):
-    def test_matches_paths_not_following_board_label_rules(self, get_build_attributes_by_board_type):
-        build_attributes = mock.Mock(
-            MbedTargetBuildAttributes, labels={"T"}, features={"F"}, components={"C"}
+    def test_matches_paths_not_following_board_label_rules(self, get_target_by_board_type):
+        target = mock.Mock(
+            Target, labels={"T"}, features={"F"}, components={"C"}
         )  # Zero interface safety here, dataclasses don't support spec_set
-        get_build_attributes_by_board_type.return_value = build_attributes
+        get_target_by_board_type.return_value = target
         mbed_program_directory = Path("some-program")
         board_type = "K64F"
 
@@ -98,13 +98,13 @@ class TestBoardLabelFilter(TestCase):
         self.assertFalse(subject(Path("TARGET_T", "FEATURE_X")))
         self.assertFalse(subject(Path("TARGET_T", "FEATURE_F", "COMPONENT_X")))
 
-        get_build_attributes_by_board_type.assert_called_with(board_type, mbed_program_directory)
+        get_target_by_board_type.assert_called_with(board_type, mbed_program_directory)
 
-    def test_does_not_match_paths_following_board_label_rules(self, get_build_attributes_by_board_type):
-        build_attributes = mock.Mock(
-            MbedTargetBuildAttributes, labels={"T"}, features={"F"}, components={"C"}
+    def test_does_not_match_paths_following_board_label_rules(self, get_target_by_board_type):
+        target = mock.Mock(
+            Target, labels={"T"}, features={"F"}, components={"C"}
         )  # Zero interface safety here, dataclasses don't support spec_set
-        get_build_attributes_by_board_type.return_value = build_attributes
+        get_target_by_board_type.return_value = target
         mbed_program_directory = Path("some-program")
         board_type = "K64F"
 
@@ -114,7 +114,7 @@ class TestBoardLabelFilter(TestCase):
         self.assertTrue(subject(Path("TARGET_T", "FEATURE_F")))
         self.assertTrue(subject(Path("TARGET_T", "FEATURE_F", "COMPONENT_C")))
 
-        get_build_attributes_by_board_type.assert_called_with(board_type, mbed_program_directory)
+        get_target_by_board_type.assert_called_with(board_type, mbed_program_directory)
 
 
 class TestLabelFilter(TestCase):

--- a/tests/test_mbed_build.py
+++ b/tests/test_mbed_build.py
@@ -12,22 +12,19 @@ from mbed_build.mbed_build import generate_cmakelists_file, export_cmakelists_fi
 
 class TestGenerateCMakeListsFile(TestCase):
     @mock.patch("mbed_build.mbed_build.render_cmakelists_template")
-    @mock.patch("mbed_build.mbed_build.get_build_attributes_by_board_type")
-    def test_correct_arguments_passed(self, get_build_attributes_by_board_type, render_cmakelists_template):
-        target_build_attributes = mock.Mock()
-        get_build_attributes_by_board_type.return_value = target_build_attributes
+    @mock.patch("mbed_build.mbed_build.get_target_by_name")
+    def test_correct_arguments_passed(self, get_target_by_name, render_cmakelists_template):
+        target = mock.Mock()
+        get_target_by_name.return_value = target
         mbed_target = "K64F"
         project_path = "blinky"
         toolchain_name = "GCC"
 
         generate_cmakelists_file(mbed_target, project_path, toolchain_name)
 
-        get_build_attributes_by_board_type.assert_called_once_with(mbed_target, project_path)
+        get_target_by_name.assert_called_once_with(mbed_target, project_path)
         render_cmakelists_template.assert_called_once_with(
-            target_build_attributes.labels,
-            target_build_attributes.features,
-            target_build_attributes.components,
-            toolchain_name,
+            target.labels, target.features, target.components, toolchain_name,
         )
 
 


### PR DESCRIPTION
### Description
Update code to work with the new naming in mbed-targets.

The tests will fail in the CI until the changes have been released in mbed-targets, but putting this up as a PR anyway so we can see the effect of the renaming. 


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
