### PR TITLE
♻️ Configuration assembly fixes

### DIFF
--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Build configuration abstraction layer."""
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Optional
+from typing_extensions import TypedDict
 
 from mbed_build._internal.config.config_layer import ConfigLayer
 

--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -3,22 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Build configuration abstraction layer."""
-from dataclasses import dataclass, field
-from typing import List
+from typing import Any, Dict, List, Optional, TypedDict
 
 from mbed_build._internal.config.config_layer import ConfigLayer
 
 
-@dataclass
-class Config:
+class Setting(TypedDict):
+    """Represents a config setting."""
+
+    help: Optional[str]
+    value: Any
+
+
+class Config(TypedDict):
     """Represents a build configuration."""
 
-    settings: dict = field(default_factory=dict)
+    settings: Dict[str, Setting]
 
-    @classmethod
-    def from_layers(cls, layers: List[ConfigLayer]) -> "Config":
-        """Create configuration from layers."""
-        config = cls()
-        for layer in layers:
-            config = layer.apply(config)
-        return config
+
+def build_config_from_layers(layers: List[ConfigLayer]) -> Config:
+    """Create configuration from layers."""
+    config = Config(settings={})
+    for layer in layers:
+        layer.apply(config)
+    return config

--- a/mbed_build/_internal/config/config_modifiers.py
+++ b/mbed_build/_internal/config/config_modifiers.py
@@ -30,10 +30,7 @@ class SetConfigValue:
         """Mutate config by overwriting existing entry with new data."""
         existing = config["settings"].get(self.key)
         if existing:
-            config["settings"][self.key] = {
-                "value": self.value,
-                "help": existing["help"],
-            }
+            config["settings"][self.key]["value"] = self.value
         else:
             config["settings"][self.key] = {
                 "value": self.value,

--- a/mbed_build/_internal/config/config_modifiers.py
+++ b/mbed_build/_internal/config/config_modifiers.py
@@ -26,14 +26,19 @@ class SetConfigValue:
     value: Any
     help: Optional[str]
 
-    def __call__(self, config: "Config") -> "Config":
+    def __call__(self, config: "Config") -> None:
         """Mutate config by overwriting existing entry with new data."""
-        existing = config.settings.get(self.key, {})
-        override = {"value": self.value}
-        if self.help:
-            override["help"] = self.help
-        config.settings[self.key] = {**existing, **override}
-        return config
+        existing = config["settings"].get(self.key)
+        if existing:
+            config["settings"][self.key] = {
+                "value": self.value,
+                "help": existing["help"],
+            }
+        else:
+            config["settings"][self.key] = {
+                "value": self.value,
+                "help": self.help,
+            }
 
     @classmethod
     def build(cls, key: str, data: Any) -> "SetConfigValue":
@@ -59,6 +64,6 @@ def build_modifier_from_config_entry(key: str, data: Any) -> Callable:
 
 
 def build_modifier_from_target_override_entry(key: str, data: Any) -> Callable:
-    """Target overrides come in three shapes: addition, removal and override."""
+    """TODO."""
     # TODO: handle add/remove cumulative overrides
     return SetConfigValue.build(key, data)

--- a/mbed_build/_internal/config/config_modifiers.py
+++ b/mbed_build/_internal/config/config_modifiers.py
@@ -30,7 +30,7 @@ class SetConfigValue:
         """Mutate config by overwriting existing entry with new data."""
         existing = config["settings"].get(self.key)
         if existing:
-            config["settings"][self.key]["value"] = self.value
+            existing["value"] = self.value
         else:
             config["settings"][self.key] = {
                 "value": self.value,

--- a/mbed_build/_internal/config/config_modifiers.py
+++ b/mbed_build/_internal/config/config_modifiers.py
@@ -61,6 +61,5 @@ def build_modifier_from_config_entry(key: str, data: Any) -> Callable:
 
 
 def build_modifier_from_target_override_entry(key: str, data: Any) -> Callable:
-    """TODO."""
-    # TODO: handle add/remove cumulative overrides
+    """TODO: handle add/remove cumulative overrides."""
     return SetConfigValue.build(key, data)

--- a/news/20200415.misc
+++ b/news/20200415.misc
@@ -1,0 +1,1 @@
+Configuration assembly - typing fixes, explicit mutation, use TypedDict

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -4,6 +4,7 @@
 #
 import factory
 
+from mbed_build._internal.config.config import Config
 from mbed_build._internal.config.config_source import ConfigSource
 
 
@@ -15,3 +16,11 @@ class ConfigSourceFactory(factory.Factory):
     file = factory.Faker("file_path", extension="json")
     config = factory.Dict({})
     target_overrides = factory.Dict({})
+
+
+class ConfigFactory(factory.Factory):
+    class Meta:
+        model = Config
+
+    settings = factory.Dict({})
+    features = factory.List([])

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -13,7 +13,19 @@ from tests._internal.config.factories import ConfigSourceFactory
 class TestFromLayers(TestCase):
     def test_assembles_config_from_layers(self):
         source_1 = ConfigSourceFactory(**{"config": {"is-nice": {"help": "Determine if app is nice", "value": True}}})
-        source_2 = ConfigSourceFactory(**{"config": {"is-fast": True}, "target_overrides": {"*": {"is-nice": False}}})
+        source_2 = ConfigSourceFactory(**{"config": {"is-fast": False}})
+        layer_1 = ConfigLayer.from_config_source(source_1, ["DOES_NOT_MATTER"])
+        layer_2 = ConfigLayer.from_config_source(source_2, ["DOES_NOT_MATTER"])
+
+        subject = Config.from_layers([layer_1, layer_2])
+
+        self.assertEqual(subject.settings["is-nice"]["value"], True)
+        self.assertEqual(subject.settings["is-nice"]["help"], "Determine if app is nice")
+        self.assertEqual(subject.settings["is-fast"]["value"], False)
+
+    def test_respects_target_overrides(self):
+        source_1 = ConfigSourceFactory(**{"config": {"is-nice": True}})
+        source_2 = ConfigSourceFactory(**{"target_overrides": {"*": {"is-nice": False}}})
         source_3 = ConfigSourceFactory(**{"target_overrides": {"NOT_THIS_TARGET": {"is-nice": True}}})
         layer_1 = ConfigLayer.from_config_source(source_1, ["TARGET"])
         layer_2 = ConfigLayer.from_config_source(source_2, ["TARGET"])
@@ -21,7 +33,4 @@ class TestFromLayers(TestCase):
 
         subject = Config.from_layers([layer_1, layer_2, layer_3])
 
-        expected_config = Config(
-            settings={"is-nice": {"help": "Determine if app is nice", "value": False}, "is-fast": {"value": True}},
-        )
-        self.assertEqual(subject, expected_config)
+        self.assertEqual(subject.settings["is-nice"]["value"], False)

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -4,24 +4,23 @@
 #
 from unittest import TestCase
 
-from mbed_build._internal.config.config import Config
+from mbed_build._internal.config.config import build_config_from_layers
 from mbed_build._internal.config.config_layer import ConfigLayer
-
 from tests._internal.config.factories import ConfigSourceFactory
 
 
-class TestFromLayers(TestCase):
+class TestBuildFromLayers(TestCase):
     def test_assembles_config_from_layers(self):
         source_1 = ConfigSourceFactory(**{"config": {"is-nice": {"help": "Determine if app is nice", "value": True}}})
         source_2 = ConfigSourceFactory(**{"config": {"is-fast": False}})
         layer_1 = ConfigLayer.from_config_source(source_1, ["DOES_NOT_MATTER"])
         layer_2 = ConfigLayer.from_config_source(source_2, ["DOES_NOT_MATTER"])
 
-        subject = Config.from_layers([layer_1, layer_2])
+        subject = build_config_from_layers([layer_1, layer_2])
 
-        self.assertEqual(subject.settings["is-nice"]["value"], True)
-        self.assertEqual(subject.settings["is-nice"]["help"], "Determine if app is nice")
-        self.assertEqual(subject.settings["is-fast"]["value"], False)
+        self.assertEqual(subject["settings"]["is-nice"]["value"], True)
+        self.assertEqual(subject["settings"]["is-nice"]["help"], "Determine if app is nice")
+        self.assertEqual(subject["settings"]["is-fast"]["value"], False)
 
     def test_respects_target_overrides(self):
         source_1 = ConfigSourceFactory(**{"config": {"is-nice": True}})
@@ -31,6 +30,6 @@ class TestFromLayers(TestCase):
         layer_2 = ConfigLayer.from_config_source(source_2, ["TARGET"])
         layer_3 = ConfigLayer.from_config_source(source_3, ["TARGET"])
 
-        subject = Config.from_layers([layer_1, layer_2, layer_3])
+        subject = build_config_from_layers([layer_1, layer_2, layer_3])
 
-        self.assertEqual(subject.settings["is-nice"]["value"], False)
+        self.assertEqual(subject["settings"]["is-nice"]["value"], False)

--- a/tests/_internal/config/test_config_layer.py
+++ b/tests/_internal/config/test_config_layer.py
@@ -4,20 +4,19 @@
 #
 from unittest import TestCase, mock
 
-from mbed_build._internal.config.config import Config
 from mbed_build._internal.config.config_layer import ConfigLayer
 from mbed_build._internal.config.config_modifiers import (
     build_modifier_from_config_entry,
     build_modifier_from_target_override_entry,
 )
-from tests._internal.config.factories import ConfigSourceFactory
+from tests._internal.config.factories import ConfigSourceFactory, ConfigFactory
 
 
 class TestApply(TestCase):
     def test_applies_all_modifiers_to_config(self):
         modifier_1 = mock.Mock()
         modifier_2 = mock.Mock()
-        config = Config()
+        config = ConfigFactory()
         config_layer = ConfigLayer(modifiers=[modifier_1, modifier_2], config_source=ConfigSourceFactory())
 
         subject = config_layer.apply(config)

--- a/tests/_internal/config/test_config_modifiers.py
+++ b/tests/_internal/config/test_config_modifiers.py
@@ -4,16 +4,16 @@
 #
 from unittest import TestCase
 
-from mbed_build._internal.config.config import Config
 from mbed_build._internal.config.config_modifiers import (
     build_modifier_from_config_entry,
     build_modifier_from_target_override_entry,
     SetConfigValue,
 )
+from tests._internal.config.factories import ConfigFactory
 
 
 class TestBuildModifierFromConfigEntry(TestCase):
-    def test_builds_set_config_value_instance(self):
+    def test_builds_set_config_value_modifier(self):
         subject = build_modifier_from_config_entry("some-key", 123)
 
         self.assertEqual(
@@ -22,7 +22,7 @@ class TestBuildModifierFromConfigEntry(TestCase):
 
 
 class TestBuildModifierFromTargetOverrideEntry(TestCase):
-    def test_builds_set_config_value_instance(self):
+    def test_builds_set_config_value_modifier(self):
         subject = build_modifier_from_target_override_entry("some-key", 123)
 
         self.assertEqual(
@@ -42,18 +42,17 @@ class TestSetConfigValue(TestCase):
         self.assertEqual(subject, SetConfigValue(key="level", value=1, help="TFM security level"))
 
     def test_sets_new_value(self):
-        config = Config()
+        config = ConfigFactory()
         modifier = SetConfigValue(key="foo", value="value", help="help")
 
-        config = modifier(config)
+        modifier(config)
 
-        self.assertEqual(config.settings["foo"], {"value": "value", "help": "help"})
+        self.assertEqual(config["settings"]["foo"], {"value": "value", "help": "help"})
 
     def test_overwrites_existing_value(self):
-        config = Config()
-        config.settings["bar"] = {"value": "swag", "help": "please help"}
+        config = ConfigFactory(settings={"bar": {"value": "swag", "help": "please help"}})
         modifier = SetConfigValue(key="bar", value=123, help=None)
 
-        config = modifier(config)
+        modifier(config)
 
-        self.assertEqual(config.settings["bar"], {"value": 123, "help": "please help"})
+        self.assertEqual(config["settings"]["bar"], {"value": 123, "help": "please help"})


### PR DESCRIPTION
### Description

1. Turns out that w/o `__init__.py` mypy does not care about your types - adding missing file.
2. Split config assembly integration test into two separate ones - one dealing with simplest case, other with target overrides.
3. Use `TypedDict` instead of `dataclass`. Rationale is that I'm mutating state anyway (😨) so why not treat the entire configuration object as a dict - the dot access vs dict key distinction is a tad confusing.
4. Make mutation more explicit.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
