### PR TITLE
✨ Handle strict cumulative overrides

### DIFF
--- a/mbed_build/_internal/config/config_modifiers/build_modifiers.py
+++ b/mbed_build/_internal/config/config_modifiers/build_modifiers.py
@@ -20,6 +20,11 @@ def build_modifier_from_target_override_entry(key: str, data: Any) -> Callable:
     - cumulative override (for a specific set of keys)
     - regular config setting override (everything else)
     """
+    # Strip optional target prefix
+    prefix = "target."
+    if key.startswith(prefix):
+        key = key[len(prefix) :]
+
     try:
         return set_target_attribute.build(key, data)
     except set_target_attribute.InvalidModifierData:

--- a/news/20200417.feature
+++ b/news/20200417.feature
@@ -1,0 +1,1 @@
+Strict cumulative overrides

--- a/tests/_internal/config/config_modifiers/test_build_modifiers.py
+++ b/tests/_internal/config/config_modifiers/test_build_modifiers.py
@@ -41,3 +41,14 @@ class TestBuildModifierFromTargetOverrideEntry(TestCase):
 
         self.assertEqual(build_modifier_from_target_override_entry(key, data), set_config_setting_build.return_value)
         set_config_setting_build.assert_called_once_with(key, data)
+
+    @mock.patch("mbed_build._internal.config.config_modifiers.build_modifiers.set_target_attribute.build")
+    @mock.patch("mbed_build._internal.config.config_modifiers.build_modifiers.set_config_setting.build")
+    def test_strips_target_prefix(self, set_config_setting_build, set_target_attribute_build):
+        set_target_attribute_build.side_effect = InvalidModifierData
+        key = "target.hat"
+        data = "boat"
+
+        self.assertEqual(build_modifier_from_target_override_entry(key, data), set_config_setting_build.return_value)
+        set_target_attribute_build.assert_called_once_with("hat", data)
+        set_config_setting_build.assert_called_once_with("hat", data)

--- a/tests/_internal/config/config_modifiers/test_set_target_attribute.py
+++ b/tests/_internal/config/config_modifiers/test_set_target_attribute.py
@@ -8,6 +8,7 @@ from mbed_build._internal.config.config_modifiers.set_target_attribute import (
     AppendToTargetAttribute,
     ACCUMULATING_OVERRIDES,
     RemoveFromTargetAttribute,
+    OverwriteTargetAttribute,
     InvalidModifierData,
     build,
 )
@@ -15,19 +16,26 @@ from tests._internal.config.factories import ConfigFactory
 
 
 class TestBuild(TestCase):
-    def test_builds_append_value_modifier_for_cumulative_overrides(self):
+    def test_builds_append_modifier(self):
         for override in ACCUMULATING_OVERRIDES:
             with self.subTest('builds append value modifier for "{override}" override'):
-                subject = build(f"target.{override}_add", ["FOO"])
+                subject = build(f"{override}_add", ["FOO"])
 
                 self.assertEqual(subject, AppendToTargetAttribute(key=override, value=["FOO"]))
 
-    def test_builds_remove_value_modifier(self):
+    def test_builds_remove_modifier(self):
         for override in ACCUMULATING_OVERRIDES:
             with self.subTest('builds remove value modifier for "{override}" override'):
-                subject = build(f"target.{override}_remove", ["BAR"])
+                subject = build(f"{override}_remove", ["BAR"])
 
                 self.assertEqual(subject, RemoveFromTargetAttribute(key=override, value=["BAR"]))
+
+    def test_builds_override_modifier(self):
+        for override in ACCUMULATING_OVERRIDES:
+            with self.subTest('builds override value modifier for "{override}" override'):
+                subject = build(f"{override}", ["BAR"])
+
+                self.assertEqual(subject, OverwriteTargetAttribute(key=override, value=["BAR"]))
 
     def test_raises_given_invalid_key(self):
         with self.assertRaises(InvalidModifierData):

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -47,3 +47,15 @@ class TestBuildFromLayers(TestCase):
         subject = build_config_from_layers([layer_1, layer_2, layer_3])
 
         self.assertEqual(subject["target"]["features"], set(["FEATURE_1", "FEATURE_3"]))
+
+    def test_respects_strict_cumulative_overrides(self):
+        source_1 = ConfigSourceFactory(
+            **{"target_overrides": {"*": {"target.features_add": ["FEATURE_1", "FEATURE_2"]}}}
+        )
+        source_2 = ConfigSourceFactory(**{"target_overrides": {"*": {"target.features": ["FEATURE_2"]}}})
+        layer_1 = ConfigLayer.from_config_source(source_1, ["K64F"])
+        layer_2 = ConfigLayer.from_config_source(source_2, ["K64F"])
+
+        subject = build_config_from_layers([layer_1, layer_2])
+
+        self.assertEqual(subject["target"]["features"], set(["FEATURE_2"]))


### PR DESCRIPTION
### Description

When a cumulative target override has no `_add` or `_remove` suffix, the cumulative value should be overwritten with new contents.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
