### PR TITLE
✨ Configuration assembly namespaces

### DIFF
--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -44,5 +44,5 @@ def build_config_from_layers(layers: List[ConfigLayer]) -> Config:
 def _empty_config() -> Config:
     return Config(
         settings={},
-        target={"components": set(), "device_has": set(), "extra_labels": set(), "features": set(), "macros": set(),},
+        target={"components": set(), "device_has": set(), "extra_labels": set(), "features": set(), "macros": set()},
     )

--- a/mbed_build/_internal/config/config_layer.py
+++ b/mbed_build/_internal/config/config_layer.py
@@ -43,36 +43,14 @@ class ConfigLayer:
 
         This method translates data found in ConfigSource into modifiers specific to the given target.
         """
-        namespace = config_source.namespace
         modifiers = []
         for key, data in config_source.config.items():
-            modifiers.append(build_modifier_from_config_entry(key=_namespace(key, namespace), data=data))
+            modifiers.append(build_modifier_from_config_entry(key=key, data=data))
 
         allowed_target_labels = ["*"] + target_labels
         for target_label, overrides in config_source.target_overrides.items():
             if target_label in allowed_target_labels:
                 for key, data in overrides.items():
-                    modifiers.append(
-                        build_modifier_from_target_override_entry(key=_namespace(key, namespace), data=data)
-                    )
+                    modifiers.append(build_modifier_from_target_override_entry(key=key, data=data))
 
         return cls(config_source=config_source, modifiers=modifiers)
-
-
-def _namespace(key: str, namespace: str) -> str:
-    """Prefix configuration key with a namespace.
-
-    Namespace is ConfigSource wide, and is resolved at source build time.
-
-    It should be one of:
-    - "target"
-    - "application"
-    - library name (where "mbed_lib.json" comes from)
-
-    If given key is already namespaced, return it as is - this is going to be the case for
-    keys from "target_overrides" entries. Keys from "config" usually need namespacing.
-    """
-    if "." in key:
-        return key
-    else:
-        return f"{namespace}.{key}"

--- a/mbed_build/_internal/config/config_source.py
+++ b/mbed_build/_internal/config/config_source.py
@@ -20,18 +20,29 @@ class ConfigSource:
     This class serves as a common interface for interrogating sources listed above.
     """
 
-    name: str
     file: pathlib.Path
     config: dict
     target_overrides: dict
 
     @classmethod
-    def from_file(cls, json_file: pathlib.Path) -> "ConfigSource":
-        """Read json file and build new ConfigSource."""
+    def from_mbed_lib(cls, json_file: pathlib.Path) -> "ConfigSource":
+        """Read mbed_lib.json file and build new ConfigSource."""
         contents = json.loads(json_file.read_text())
-        return cls(
-            file=json_file,
-            name=contents["name"],
-            config=contents.get("config", {}),
-            target_overrides=contents.get("target_overrides", {}),
-        )
+        name = contents["name"]
+
+        config = contents.get("config", {})
+        namespaced_config = {_add_namespace(key, name): value for key, value in config.items()}
+
+        namespaced_target_overrides = {}
+        target_overrides = contents.get("target_overrides", {})
+        for key, value in target_overrides.items():
+            namespaced_target_overrides[key] = {_add_namespace(key, name): value for key, value in value.items()}
+
+        return cls(file=json_file, config=namespaced_config, target_overrides=namespaced_target_overrides)
+
+
+def _add_namespace(key, namespace):
+    # If key is already namespaced, don't touch it
+    if "." in key:
+        return key
+    return f"{namespace}.{key}"

--- a/mbed_build/_internal/config/config_source.py
+++ b/mbed_build/_internal/config/config_source.py
@@ -20,6 +20,7 @@ class ConfigSource:
     This class serves as a common interface for interrogating sources listed above.
     """
 
+    namespace: str
     file: pathlib.Path
     config: dict
     target_overrides: dict
@@ -28,21 +29,7 @@ class ConfigSource:
     def from_mbed_lib(cls, json_file: pathlib.Path) -> "ConfigSource":
         """Read mbed_lib.json file and build new ConfigSource."""
         contents = json.loads(json_file.read_text())
-        name = contents["name"]
-
+        namespace = contents["name"]
         config = contents.get("config", {})
-        namespaced_config = {_add_namespace(key, name): value for key, value in config.items()}
-
-        namespaced_target_overrides = {}
         target_overrides = contents.get("target_overrides", {})
-        for key, value in target_overrides.items():
-            namespaced_target_overrides[key] = {_add_namespace(key, name): value for key, value in value.items()}
-
-        return cls(file=json_file, config=namespaced_config, target_overrides=namespaced_target_overrides)
-
-
-def _add_namespace(key, namespace):
-    # If key is already namespaced, don't touch it
-    if "." in key:
-        return key
-    return f"{namespace}.{key}"
+        return cls(namespace=namespace, file=json_file, config=config, target_overrides=target_overrides)

--- a/mbed_build/_internal/config/config_source.py
+++ b/mbed_build/_internal/config/config_source.py
@@ -48,7 +48,7 @@ def _namespace_key(key: str, namespace: str) -> str:
 
     It should be one of:
     - "target"
-    - "application"
+    - "app"
     - library name (where "mbed_lib.json" comes from)
 
     If given key is already namespaced, return it as is - this is going to be the case for

--- a/mbed_build/_internal/config/config_source.py
+++ b/mbed_build/_internal/config/config_source.py
@@ -6,7 +6,6 @@
 import json
 import pathlib
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
@@ -21,7 +20,7 @@ class ConfigSource:
     This class serves as a common interface for interrogating sources listed above.
     """
 
-    name: Optional[str]
+    name: str
     file: pathlib.Path
     config: dict
     target_overrides: dict
@@ -32,7 +31,7 @@ class ConfigSource:
         contents = json.loads(json_file.read_text())
         return cls(
             file=json_file,
-            name=contents.get("name", None),
+            name=contents["name"],
             config=contents.get("config", {}),
             target_overrides=contents.get("target_overrides", {}),
         )

--- a/news/20200420.feature
+++ b/news/20200420.feature
@@ -1,0 +1,1 @@
+Configuration namespacing

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -12,6 +12,7 @@ class ConfigSourceFactory(factory.Factory):
     class Meta:
         model = ConfigSource
 
+    namespace = factory.Faker("slug")
     file = factory.Faker("file_path", extension="json")
     config = factory.Dict({})
     target_overrides = factory.Dict({})

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -12,7 +12,6 @@ class ConfigSourceFactory(factory.Factory):
     class Meta:
         model = ConfigSource
 
-    namespace = factory.Faker("slug")
     file = factory.Faker("file_path", extension="json")
     config = factory.Dict({})
     target_overrides = factory.Dict({})

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -12,7 +12,7 @@ class ConfigSourceFactory(factory.Factory):
     class Meta:
         model = ConfigSource
 
-    name = factory.Faker("name")
+    name = factory.Faker("slug")
     file = factory.Faker("file_path", extension="json")
     config = factory.Dict({})
     target_overrides = factory.Dict({})

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -12,7 +12,6 @@ class ConfigSourceFactory(factory.Factory):
     class Meta:
         model = ConfigSource
 
-    name = factory.Faker("slug")
     file = factory.Faker("file_path", extension="json")
     config = factory.Dict({})
     target_overrides = factory.Dict({})

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -11,30 +11,28 @@ from tests._internal.config.factories import ConfigSourceFactory
 
 class TestBuildFromLayers(TestCase):
     def test_assembles_config_from_layers(self):
-        source_1 = ConfigSourceFactory(
-            namespace="foo", config={"is-nice": {"help": "Determine if app is nice", "value": True}}
-        )
-        source_2 = ConfigSourceFactory(namespace="bar", config={"a-number": 123})
+        source_1 = ConfigSourceFactory(config={"is-nice": {"help": "Determine if app is nice", "value": True}})
+        source_2 = ConfigSourceFactory(config={"a-number": 123})
         layer_1 = ConfigLayer.from_config_source(source_1, ["DOES_NOT_MATTER"])
         layer_2 = ConfigLayer.from_config_source(source_2, ["DOES_NOT_MATTER"])
 
         subject = build_config_from_layers([layer_1, layer_2])
 
-        self.assertEqual(subject["settings"]["foo.is-nice"]["value"], True)
-        self.assertEqual(subject["settings"]["foo.is-nice"]["help"], "Determine if app is nice")
-        self.assertEqual(subject["settings"]["bar.a-number"]["value"], 123)
+        self.assertEqual(subject["settings"]["is-nice"]["value"], True)
+        self.assertEqual(subject["settings"]["is-nice"]["help"], "Determine if app is nice")
+        self.assertEqual(subject["settings"]["a-number"]["value"], 123)
 
     def test_respects_target_overrides(self):
-        source_1 = ConfigSourceFactory(namespace="s1", config={"is-nice": True})
-        source_2 = ConfigSourceFactory(namespace="s2", target_overrides={"*": {"s1.is-nice": False}})
-        source_3 = ConfigSourceFactory(namespace="s3", target_overrides={"NOT_THIS_TARGET": {"s1.is-nice": True}})
+        source_1 = ConfigSourceFactory(config={"is-nice": True})
+        source_2 = ConfigSourceFactory(target_overrides={"*": {"is-nice": False}})
+        source_3 = ConfigSourceFactory(target_overrides={"NOT_THIS_TARGET": {"is-nice": True}})
         layer_1 = ConfigLayer.from_config_source(source_1, ["TARGET"])
         layer_2 = ConfigLayer.from_config_source(source_2, ["TARGET"])
         layer_3 = ConfigLayer.from_config_source(source_3, ["TARGET"])
 
         subject = build_config_from_layers([layer_1, layer_2, layer_3])
 
-        self.assertEqual(subject["settings"]["s1.is-nice"]["value"], False)
+        self.assertEqual(subject["settings"]["is-nice"]["value"], False)
 
     def test_respects_cumulative_overrides(self):
         source_1 = ConfigSourceFactory(

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -11,28 +11,30 @@ from tests._internal.config.factories import ConfigSourceFactory
 
 class TestBuildFromLayers(TestCase):
     def test_assembles_config_from_layers(self):
-        source_1 = ConfigSourceFactory(**{"config": {"is-nice": {"help": "Determine if app is nice", "value": True}}})
-        source_2 = ConfigSourceFactory(**{"config": {"is-fast": False}})
+        source_1 = ConfigSourceFactory(
+            namespace="foo", config={"is-nice": {"help": "Determine if app is nice", "value": True}}
+        )
+        source_2 = ConfigSourceFactory(namespace="bar", config={"a-number": 123})
         layer_1 = ConfigLayer.from_config_source(source_1, ["DOES_NOT_MATTER"])
         layer_2 = ConfigLayer.from_config_source(source_2, ["DOES_NOT_MATTER"])
 
         subject = build_config_from_layers([layer_1, layer_2])
 
-        self.assertEqual(subject["settings"]["is-nice"]["value"], True)
-        self.assertEqual(subject["settings"]["is-nice"]["help"], "Determine if app is nice")
-        self.assertEqual(subject["settings"]["is-fast"]["value"], False)
+        self.assertEqual(subject["settings"]["foo.is-nice"]["value"], True)
+        self.assertEqual(subject["settings"]["foo.is-nice"]["help"], "Determine if app is nice")
+        self.assertEqual(subject["settings"]["bar.a-number"]["value"], 123)
 
     def test_respects_target_overrides(self):
-        source_1 = ConfigSourceFactory(**{"config": {"is-nice": True}})
-        source_2 = ConfigSourceFactory(**{"target_overrides": {"*": {"is-nice": False}}})
-        source_3 = ConfigSourceFactory(**{"target_overrides": {"NOT_THIS_TARGET": {"is-nice": True}}})
+        source_1 = ConfigSourceFactory(namespace="s1", config={"is-nice": True})
+        source_2 = ConfigSourceFactory(namespace="s2", target_overrides={"*": {"s1.is-nice": False}})
+        source_3 = ConfigSourceFactory(namespace="s3", target_overrides={"NOT_THIS_TARGET": {"s1.is-nice": True}})
         layer_1 = ConfigLayer.from_config_source(source_1, ["TARGET"])
         layer_2 = ConfigLayer.from_config_source(source_2, ["TARGET"])
         layer_3 = ConfigLayer.from_config_source(source_3, ["TARGET"])
 
         subject = build_config_from_layers([layer_1, layer_2, layer_3])
 
-        self.assertEqual(subject["settings"]["is-nice"]["value"], False)
+        self.assertEqual(subject["settings"]["s1.is-nice"]["value"], False)
 
     def test_respects_cumulative_overrides(self):
         source_1 = ConfigSourceFactory(

--- a/tests/_internal/config/test_config_layer.py
+++ b/tests/_internal/config/test_config_layer.py
@@ -4,7 +4,7 @@
 #
 from unittest import TestCase, mock
 
-from mbed_build._internal.config.config_layer import ConfigLayer
+from mbed_build._internal.config.config_layer import ConfigLayer, _namespace
 from mbed_build._internal.config.config_modifiers import (
     build_modifier_from_config_entry,
     build_modifier_from_target_override_entry,
@@ -27,8 +27,9 @@ class TestApply(TestCase):
 
 
 class TestFromConfigSource(TestCase):
-    def test_creates_config_layer_with_modifiers_from_config_source(self):
+    def test_creates_config_layer_with_namespaced_modifiers_from_config_source(self):
         config_source = ConfigSourceFactory(
+            namespace="namespace",
             config={"foo": True},
             target_overrides={
                 "*": {"bar": 1},
@@ -44,9 +45,17 @@ class TestFromConfigSource(TestCase):
             ConfigLayer(
                 config_source=config_source,
                 modifiers=[
-                    build_modifier_from_config_entry(key="foo", data=True),
-                    build_modifier_from_target_override_entry(key="bar", data=1),
-                    build_modifier_from_target_override_entry(key="baz", data="maybe"),
+                    build_modifier_from_config_entry(key=_namespace("foo", "namespace"), data=True),
+                    build_modifier_from_target_override_entry(key=_namespace("bar", "namespace"), data=1),
+                    build_modifier_from_target_override_entry(key=_namespace("baz", "namespace"), data="maybe"),
                 ],
             ),
         )
+
+
+class TestNamespace(TestCase):
+    def test_leaves_namespaced_keys_alone(self):
+        self.assertEqual(_namespace("target.foo", "my-namespace"), "target.foo")
+
+    def test_namespaces_keys(self):
+        self.assertEqual(_namespace("foo", "my-namespace"), "my-namespace.foo")

--- a/tests/_internal/config/test_config_layer.py
+++ b/tests/_internal/config/test_config_layer.py
@@ -4,7 +4,7 @@
 #
 from unittest import TestCase, mock
 
-from mbed_build._internal.config.config_layer import ConfigLayer, _namespace
+from mbed_build._internal.config.config_layer import ConfigLayer
 from mbed_build._internal.config.config_modifiers import (
     build_modifier_from_config_entry,
     build_modifier_from_target_override_entry,
@@ -27,9 +27,8 @@ class TestApply(TestCase):
 
 
 class TestFromConfigSource(TestCase):
-    def test_creates_config_layer_with_namespaced_modifiers_from_config_source(self):
+    def test_creates_config_layer_modifiers_from_config_source(self):
         config_source = ConfigSourceFactory(
-            namespace="namespace",
             config={"foo": True},
             target_overrides={
                 "*": {"bar": 1},
@@ -45,17 +44,9 @@ class TestFromConfigSource(TestCase):
             ConfigLayer(
                 config_source=config_source,
                 modifiers=[
-                    build_modifier_from_config_entry(key=_namespace("foo", "namespace"), data=True),
-                    build_modifier_from_target_override_entry(key=_namespace("bar", "namespace"), data=1),
-                    build_modifier_from_target_override_entry(key=_namespace("baz", "namespace"), data="maybe"),
+                    build_modifier_from_config_entry(key="foo", data=True),
+                    build_modifier_from_target_override_entry(key="bar", data=1),
+                    build_modifier_from_target_override_entry(key="baz", data="maybe"),
                 ],
             ),
         )
-
-
-class TestNamespace(TestCase):
-    def test_leaves_namespaced_keys_alone(self):
-        self.assertEqual(_namespace("target.foo", "my-namespace"), "target.foo")
-
-    def test_namespaces_keys(self):
-        self.assertEqual(_namespace("foo", "my-namespace"), "my-namespace.foo")

--- a/tests/_internal/config/test_config_source.py
+++ b/tests/_internal/config/test_config_source.py
@@ -11,7 +11,7 @@ from mbed_build._internal.config.config_source import ConfigSource
 
 
 class TestFromMbedLib(TestCase):
-    def test_builds_namespaced_config_source_from_mbed_lib_json(self):
+    def test_builds_config_source_from_mbed_lib_json(self):
         json_data = {
             "name": "ns-hal-pal",
             "config": {
@@ -34,16 +34,10 @@ class TestFromMbedLib(TestCase):
         self.assertEqual(
             subject,
             ConfigSource(
+                namespace=json_data["name"],
                 file=json_file,
-                config={
-                    "ns-hal-pal.nvm_cfstore": {
-                        "help": "Use cfstore as a NVM storage. Else RAM simulation will be used",
-                        "value": False,
-                    }
-                },
-                target_overrides={
-                    "*": {"target.some-setting": 123, "target.add_features": ["BLE"], "ns-hal-pal.rsa-required": True}
-                },
+                config=json_data["config"],
+                target_overrides=json_data["target_overrides"],
             ),
         )
 
@@ -56,4 +50,6 @@ class TestFromMbedLib(TestCase):
 
             subject = ConfigSource.from_mbed_lib(json_file)
 
-        self.assertEqual(subject, ConfigSource(file=json_file, config={}, target_overrides={}))
+        self.assertEqual(
+            subject, ConfigSource(namespace=json_data["name"], file=json_file, config={}, target_overrides={})
+        )

--- a/tests/_internal/config/test_config_source.py
+++ b/tests/_internal/config/test_config_source.py
@@ -40,7 +40,7 @@ class TestFromFile(TestCase):
         )
 
     def test_gracefully_handles_missing_data(self):
-        json_data = {}
+        json_data = {"name": "foo"}
 
         with tempfile.TemporaryDirectory() as directory:
             json_file = pathlib.Path(directory, "file.json")
@@ -48,4 +48,4 @@ class TestFromFile(TestCase):
 
             subject = ConfigSource.from_file(json_file)
 
-        self.assertEqual(subject, ConfigSource(file=json_file, name=None, config={}, target_overrides={}))
+        self.assertEqual(subject, ConfigSource(file=json_file, name="foo", config={}, target_overrides={}))

--- a/tests/_internal/config/test_config_source.py
+++ b/tests/_internal/config/test_config_source.py
@@ -7,11 +7,11 @@ import pathlib
 import tempfile
 from unittest import TestCase
 
-from mbed_build._internal.config.config_source import ConfigSource
+from mbed_build._internal.config.config_source import ConfigSource, _namespace_data
 
 
 class TestFromMbedLib(TestCase):
-    def test_builds_config_source_from_mbed_lib_json(self):
+    def test_builds_namespaced_config_source_from_mbed_lib_json(self):
         json_data = {
             "name": "ns-hal-pal",
             "config": {
@@ -34,10 +34,9 @@ class TestFromMbedLib(TestCase):
         self.assertEqual(
             subject,
             ConfigSource(
-                namespace=json_data["name"],
                 file=json_file,
-                config=json_data["config"],
-                target_overrides=json_data["target_overrides"],
+                config=_namespace_data(json_data["config"], json_data["name"]),
+                target_overrides=_namespace_data(json_data["target_overrides"], json_data["name"]),
             ),
         )
 
@@ -50,6 +49,14 @@ class TestFromMbedLib(TestCase):
 
             subject = ConfigSource.from_mbed_lib(json_file)
 
-        self.assertEqual(
-            subject, ConfigSource(namespace=json_data["name"], file=json_file, config={}, target_overrides={})
-        )
+        self.assertEqual(subject, ConfigSource(file=json_file, config={}, target_overrides={}))
+
+
+class TestNamespaceData(TestCase):
+    def test_prefixes_keys_without_namespace(self):
+        data = {
+            "foo": True,
+            "hat.bar": 123,
+        }
+
+        self.assertEqual(_namespace_data(data, "my-prefix"), {"my-prefix.foo": True, "hat.bar": 123})


### PR DESCRIPTION
### Description

To avoid configuration clashes, namespacing is required. This is an attempt to replicate namespacing rules from old tools to make this whole shenanigan work.

What I've managed to decipher:

1. `targets.json`

```
"config": {
  "foo": {...}  # becomes "target.foo": {...}
}
```

will be equivalent to `ConfigSource(namespace="target")` in new code

2. `mbed_lib.json`

```
"name": "lib_name",
"config": {
  "foo": {...} # becomes "lib_name.foo"
}
"target_overrides": {
  "*": {
    "target.foo": {...} # remains "target.foo"
    "foo": {...} # becomes "lib_name.foo"
  }
}
```

will be equivalent to`ConfigSource(namespace="lib_name")` in new code

3. `mbed_app.json` 
```
"config": {
  "foo": {...} # becomes "app.foo"
}
"target_overrides": {
  "*": {
    "target.foo": {...} # remains "target.foo"
    "some-prefix.foo": {...} # remains "some-prefix.foo"
    "foo": {...} # becomes "app.foo"
  }
}
```

will be equivalent to`ConfigSource(namespace="app")` in new code

--

Sadly, old tools configuration code is mixed with validation - something I'm not willing to replicate at this step, as it'll end up being convoluted. We can do it at later stage if it's required. FWIW: The existing validation happens both when building/reading configuration and when things are overwritten in the configuration object. It is madness - it should be a completely separate step.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
