### PR TITLE
✨ Generate Option macro name if missing

### DIFF
--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -31,7 +31,7 @@ class Option:
         Args:
             key: Namespaced configuration key
             data: Configuration data - a dict or a primitive
-            source: Source from which option data came from - used for tracing overrides
+            source: Source from which option data came - used for tracing overrides
         """
         if isinstance(data, dict):
             return cls(

--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -19,29 +19,47 @@ class Option:
     macro_name: Optional[str]
     help_text: Optional[str]
     set_by: str
+    key: str
 
     @classmethod
-    def build(cls, data: Any, source: Source) -> "Option":
+    def build(cls, key: str, data: Any, source: Source) -> "Option":
         """Build configuration option from config entry value.
 
         Config values are either complex data structures or simple values.
         This function handles both.
+
+        Args:
+            key: Namespaced configuration key
+            data: Configuration data - a dict or a primitive
+            source: Source from which option data came from - used for tracing overrides
         """
         if isinstance(data, dict):
             return cls(
+                key=key,
                 value=data.get("value"),
-                macro_name=data.get("macro_name"),
+                macro_name=data.get("macro_name", _build_macro_name(key)),
                 help_text=data.get("help"),
                 set_by=source.name,
             )
         else:
-            return cls(value=data, macro_name=None, help_text=None, set_by=source.name)
+            return cls(value=data, key=key, macro_name=_build_macro_name(key), help_text=None, set_by=source.name)
 
     def set_value(self, value: Any, source: Source) -> "Option":
         """Mutate self with new value."""
         self.value = value
         self.set_by = source.name
         return self
+
+
+def _build_macro_name(config_key: str) -> str:
+    """Build macro name for configuration key.
+
+    All configuration variables require a macro name, so that they can be referenced in a header file.
+    Some values in config define "macro_name", some don't. This helps generate consistent macro names
+    for the latter.
+    """
+    sanitised_config_key = config_key.replace(".", "_").replace("-", "_").upper()
+    return f"MBED_CONF_{sanitised_config_key}"
 
 
 @dataclass
@@ -89,7 +107,7 @@ class Config:
 
 def _create_config_option(config: Config, key: str, value: Any, source: Source) -> None:
     """Mutates Config in place by creating a new Option."""
-    config.options[key] = Option.build(value, source)
+    config.options[key] = Option.build(key, value, source)
 
 
 def _update_config_option(config: Config, key: str, value: Any, source: Source) -> None:

--- a/news/20200424.feature
+++ b/news/20200424.feature
@@ -1,0 +1,1 @@
+Generate macros for Options

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -19,9 +19,9 @@ class TestConfigFromSources(TestCase):
         self.assertEqual(
             config.options,
             {
-                "bool": Option.build(True, source_a).set_value(False, source_b),
-                "number": Option.build(1, source_b),
-                "string": Option.build("foo", source_a),
+                "bool": Option.build("bool", True, source_a).set_value(False, source_b),
+                "number": Option.build("number", 1, source_b),
+                "string": Option.build("string", "foo", source_a),
             },
         )
 
@@ -50,3 +50,35 @@ class TestConfigFromSources(TestCase):
                 config = Config.from_sources([source_a, source_b, source_c])
 
                 self.assertEqual(getattr(config.target_metadata, field.name), {"FOO", "BAZ"})
+
+
+class TestOptionBuild(TestCase):
+    def test_builds_option_from_config_data(self):
+        source = SourceFactory(name="foo")
+        data = {
+            "value": 123,
+            "help": "some help text",
+            "macro_name": "FOO_MACRO",
+        }
+        option = Option.build(key="target.stack-size", data=data, source=source)
+
+        self.assertEqual(
+            option,
+            Option(
+                key="target.stack-size",
+                value=data["value"],
+                help_text=data["help"],
+                macro_name=data["macro_name"],
+                set_by=source.name,
+            ),
+        )
+
+    def test_generates_macro_name_if_not_in_data(self):
+        source = SourceFactory()
+        data = {
+            "value": 123,
+            "help": "some help text",
+        }
+        option = Option.build(key="update-client.storage-size", data=data, source=source)
+
+        self.assertEqual(option.macro_name, "MBED_CONF_UPDATE_CLIENT_STORAGE_SIZE")


### PR DESCRIPTION
### Description

Turns out not all of the configuration options have a "macro_name" property.
Looking at old tools code explains that it is autogenerated for those:
https://github.com/ARMmbed/mbed-os/blob/64853b354fa188bfe8dbd51e78771213c7ed37f7/tools/config/__init__.py#L129



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
