### PR TITLE
✨ Configuration assembly macros

### DIFF
--- a/mbed_build/_internal/config/assemble_build_config.py
+++ b/mbed_build/_internal/config/assemble_build_config.py
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Configuration assembly algorithm."""
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Set
+from typing import Iterable
 
 from mbed_build._internal.config.config import Config
 from mbed_build._internal.config.cumulative_data import CumulativeData
@@ -13,16 +12,8 @@ from mbed_build._internal.config.source import Source
 from mbed_build._internal.find_files import LabelFilter, filter_files, find_files
 
 
-@dataclass
-class BuildConfig:
-    """Representation of build configuration."""
-
-    config: Config
-    macros: Set[str]
-
-
-def assemble_config(mbed_target: str, mbed_program_directory: Path) -> BuildConfig:
-    """Assemble BuildConfig for given target and program directory.
+def assemble_config(mbed_target: str, mbed_program_directory: Path) -> Config:
+    """Assemble Config for given target and program directory.
 
     The structure and configuration of MbedOS requires us to do multiple passes over
     configuration files, as each pass might affect which configuration files should be included
@@ -33,7 +24,7 @@ def assemble_config(mbed_target: str, mbed_program_directory: Path) -> BuildConf
     return _assemble_config(target_source, mbed_lib_files)
 
 
-def _assemble_config(target_source: Source, mbed_lib_files: Iterable[Path]) -> BuildConfig:
+def _assemble_config(target_source: Source, mbed_lib_files: Iterable[Path]) -> Config:
     previous_cumulative_data = None
     current_cumulative_data = CumulativeData.from_sources([target_source])
     while True:
@@ -46,8 +37,7 @@ def _assemble_config(target_source: Source, mbed_lib_files: Iterable[Path]) -> B
         if previous_cumulative_data == current_cumulative_data:
             break
 
-    config = Config.from_sources(all_sources)
-    return BuildConfig(config=config, macros=current_cumulative_data.macros)
+    return Config.from_sources(all_sources)
 
 
 def _filter_files(files: Iterable[Path], cumulative_data: CumulativeData) -> Iterable[Path]:

--- a/mbed_build/_internal/config/assemble_build_config.py
+++ b/mbed_build/_internal/config/assemble_build_config.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Configuration assembly algorithm."""
-import itertools
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Set

--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -21,7 +21,7 @@ class Macro:
     def build(cls, macro: str, source: Source) -> "Macro":
         """Build macro from macro string.
 
-        There's two flavours of macro strings in MbedOS configuration:
+        There are two flavours of macro strings in MbedOS configuration:
         - with value: FOO=BAR
         - without value: FOO
         """

--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -25,6 +25,7 @@ class Macro:
         - with value: FOO=BAR
         - without value: FOO
         """
+        value: Any
         if macro.find("=") != -1:
             name, value = macro.split("=")
         else:

--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -26,7 +26,7 @@ class Macro:
         - without value: FOO
         """
         value: Any
-        if macro.find("=") != -1:
+        if "=" in macro:
             name, value = macro.split("=")
         else:
             name = macro

--- a/mbed_build/_internal/config/cumulative_data.py
+++ b/mbed_build/_internal/config/cumulative_data.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 class CumulativeData:
     """Representation of cumulative attributes assembled during Source parsing."""
 
-    macros: Set[str] = field(default_factory=set)
     features: Set[str] = field(default_factory=set)
     components: Set[str] = field(default_factory=set)
     labels: Set[str] = field(default_factory=set)

--- a/mbed_build/_internal/config/source.py
+++ b/mbed_build/_internal/config/source.py
@@ -28,6 +28,7 @@ class Source:
     config: dict
     config_overrides: dict
     cumulative_overrides: dict
+    macros: Iterable[str]
 
     @classmethod
     def from_mbed_lib(cls, file: Path, target_labels: Iterable[str]) -> "Source":
@@ -48,11 +49,14 @@ class Source:
         target_specific_overrides = _namespace_data(target_specific_overrides, namespace)
         config_overrides, cumulative_overrides = _split_target_overrides_by_type(target_specific_overrides)
 
+        macros = data.get("macros", [])
+
         return cls(
             human_name=f"File: {file}",
             config=config,
             cumulative_overrides=cumulative_overrides,
             config_overrides=config_overrides,
+            macros=macros,
         )
 
     @classmethod
@@ -74,6 +78,7 @@ class Source:
             config=config,
             config_overrides={},
             cumulative_overrides=cumulative_overrides,
+            macros=[],
         )
 
 

--- a/news/20200427.feature
+++ b/news/20200427.feature
@@ -1,0 +1,1 @@
+Parse macros from configuration files

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -15,3 +15,4 @@ class SourceFactory(factory.Factory):
     config = factory.Dict({})
     config_overrides = factory.Dict({})
     cumulative_overrides = factory.Dict({})
+    macros = factory.List([])

--- a/tests/_internal/config/test_assemble_build_config.py
+++ b/tests/_internal/config/test_assemble_build_config.py
@@ -36,32 +36,29 @@ class TestConfigAssembly(TestCase):
             Path("subdir", "FEATURE_RED", "mbed_lib.json"): {
                 "name": "red",
                 "config": {"bool": False},
-                "target_overrides": {
-                    "A": {"bool": True, "target.features_add": ["BLUE"], "target.macros_add": ["RED_MACRO"]}
-                },
+                "target_overrides": {"A": {"bool": True, "target.features_add": ["BLUE"]}},
+                "macros": ["RED_MACRO"],
             },
-            Path("COMPONENT_LEG", "mbed_lib.json"): {"name": "leg", "config": {"number-of-fingers": 5}},
+            Path("COMPONENT_LEG", "mbed_lib.json"): {
+                "name": "leg",
+                "config": {"number-of-fingers": 5},
+                "macros": ["LEG_MACRO"],
+            },
         }
         unused_mbed_lib_files = {
             Path("subdir", "FEATURE_BROWN", "mbed_lib.json"): {
                 "name": "brown",
                 "target_overrides": {"*": {"red.bool": "DON'T USE ME"}},
+                "macros": ["DONT_USE_THIS_MACRO"],
             }
         }
 
-        target_source = SourceFactory(
-            cumulative_overrides={
-                "target.labels": ["A"],
-                "target.components": ["LEG"],
-                "target.macros": ["TARGET_MACRO"],
-            }
-        )
+        target_source = SourceFactory(cumulative_overrides={"target.labels": ["A"], "target.components": ["LEG"]})
 
         with create_files({**mbed_lib_files, **unused_mbed_lib_files}) as directory:
-            build_config = _assemble_config(target_source, find_files("mbed_lib.json", directory))
+            config = _assemble_config(target_source, find_files("mbed_lib.json", directory))
 
             mbed_lib_sources = [Source.from_mbed_lib(Path(directory, file), ["A"]) for file in mbed_lib_files.keys()]
             expected_config = Config.from_sources([target_source] + mbed_lib_sources)
 
-            self.assertEqual(build_config.config, expected_config)
-            self.assertEqual(build_config.macros, set(["TARGET_MACRO", "RED_MACRO"]))
+            self.assertEqual(config, expected_config)

--- a/tests/_internal/config/test_cumulative_data.py
+++ b/tests/_internal/config/test_cumulative_data.py
@@ -9,7 +9,7 @@ from mbed_build._internal.config.cumulative_data import CumulativeData
 from tests._internal.config.factories import SourceFactory
 
 
-class TestConfigCumulativeDataFromSources(TestCase):
+class TestCumulativeDataFromSources(TestCase):
     def test_assembles_metadata_from_sources(self):
         for field in fields(CumulativeData):
             with self.subTest(f"Assemble {field.name}"):

--- a/tests/_internal/config/test_source.py
+++ b/tests/_internal/config/test_source.py
@@ -19,8 +19,9 @@ class TestSource(TestCase):
                 "target_overrides": {
                     "*": {"a-number": 456, "target.features_add": ["FOO"]},
                     "NOT_THIS_TARGET": {"a-string": "foo", "target.features_add": ["BAR"]},
-                    "THIS_TARGET": {"a-bool": False, "target.macros": ["BOOM"], "other-lib.something-else": "blah"},
+                    "THIS_TARGET": {"a-bool": False, "other-lib.something-else": "blah"},
                 },
+                "macros": ["MACRO=1"],
             }
             file = pathlib.Path(directory, "mbed_lib.json")
             file.write_text(json.dumps(data))
@@ -33,7 +34,8 @@ class TestSource(TestCase):
                 human_name=f"File: {file}",
                 config={"foo.a-number": 123, "foo.a-bool": {"help": "Simply a boolean", "value": True}},
                 config_overrides={"foo.a-number": 456, "foo.a-bool": False, "other-lib.something-else": "blah"},
-                cumulative_overrides={"target.features_add": ["FOO"], "target.macros": ["BOOM"]},
+                cumulative_overrides={"target.features_add": ["FOO"]},
+                macros=["MACRO=1"],
             ),
         )
 
@@ -63,6 +65,7 @@ class TestSource(TestCase):
                     "target.components": target.components,
                     "target.labels": target.labels,
                 },
+                macros=[],
             ),
         )
 

--- a/tests/_internal/config/test_source.py
+++ b/tests/_internal/config/test_source.py
@@ -10,7 +10,7 @@ from unittest import TestCase, mock
 from mbed_build._internal.config.source import Source, _namespace_data, _filter_target_overrides
 
 
-class TestMbedLibSource(TestCase):
+class TestSource(TestCase):
     def test_from_mbed_lib(self):
         with tempfile.TemporaryDirectory() as directory:
             data = {


### PR DESCRIPTION
### Description

Turns out macros are not macros. 😑 

Macros used in configuration come from yet another config property called "macros".

---

I've been looking at the current configuration generation code and it does not seem to use macros defined standalone in targets.json. FWIW there's three ways of defining macros:
1) via "config" section - each config option has a macro - all *.json files
2) via "macros" cumulative attribute under "overrides" ("macros,macros_add,macros_remove") - only targets.json file
3) via "macros" attribute sibling to "config" and "target_overrides" - only mbed_lib.json and mbed_app.json

**The 2) does not seem to be used at all.**

Relevant piece of code: https://github.com/ARMmbed/mbed-os/blob/64853b354fa188bfe8dbd51e78771213c7ed37f7/tools/config/__init__.py#L1261
Note, that "macros" only appear after parsing mbed_lib.json files and it is from the sibling "macros" section.

Configuration dump seems to confirm those assumptions.

Macros for K64F from "config" section:
https://github.com/ARMmbed/mbed-os/blob/64853b354fa188bfe8dbd51e78771213c7ed37f7/targets/targets.json#L1468

Macros for K64F from `mbed compile --config`:
https://github.com/ARMmbed/mbed-tools-archive/blob/master/configuration_dump/K64F--ARM.txt#L442 (private repo)



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
