### PR TITLE
✨Config command

### DIFF
--- a/mbed_build/__main__.py
+++ b/mbed_build/__main__.py
@@ -1,8 +1,0 @@
-#
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
-"""Entrypoint for development purposes."""
-from mbed_build.mbed_tools import cli
-
-cli()

--- a/mbed_build/__main__.py
+++ b/mbed_build/__main__.py
@@ -9,6 +9,7 @@ from mbed_build.mbed_tools import config, export
 
 @click.group()
 def cli():
+    """Group exposing the commands from the mbed-build package."""
     pass
 
 

--- a/mbed_build/__main__.py
+++ b/mbed_build/__main__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Entrypoint for development purposes."""
+import click
+from mbed_build.mbed_tools import config, export
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(config)
+cli.add_command(export)
+
+cli()

--- a/mbed_build/__main__.py
+++ b/mbed_build/__main__.py
@@ -8,7 +8,7 @@ from mbed_build.mbed_tools import config, export
 
 
 @click.group()
-def cli():
+def cli() -> None:
     """Group exposing the commands from the mbed-build package."""
     pass
 

--- a/mbed_build/_internal/mbed_tools/config.py
+++ b/mbed_build/_internal/mbed_tools/config.py
@@ -96,7 +96,7 @@ def _build_json_output(config: Config) -> str:
 
     for macro in _config_macros_sorted_by_name(config):
         config_object["macros"].append(
-            {"name": macro.name, "value": macro.value, "set_by": macro.set_by,}
+            {"name": macro.name, "value": macro.value, "set_by": macro.set_by}
         )
 
     return json.dumps(config_object, indent=4)

--- a/mbed_build/_internal/mbed_tools/config.py
+++ b/mbed_build/_internal/mbed_tools/config.py
@@ -67,12 +67,12 @@ def _build_tabular_output(config_data: BuildConfig) -> str:
     macros_table = tabulate(macros_data, macros_table_headers)
 
     output_template = (
-        f"PARAMETER CONFIGURATION\n"
-        f"-----------------------\n"
+        "PARAMETER CONFIGURATION\n"
+        "-----------------------\n"
         f"{parameters_table}\n"
-        f"\n"
-        f"MACRO CONFIGURATION\n"
-        f"-------------------\n"
+        "\n"
+        "MACRO CONFIGURATION\n"
+        "-------------------\n"
         f"{macros_table}"
     )
 
@@ -113,12 +113,12 @@ def _build_legacy_output(config_data: BuildConfig) -> str:
         macro_list += f"{macro}\n"
 
     output_template = (
-        f"Configuration parameters\n"
-        f"------------------------\n"
+        "Configuration parameters\n"
+        "------------------------\n"
         f"{parameter_list}\n"
-        f"\n"
-        f"Macros\n"
-        f"------\n"
+        "\n"
+        "Macros\n"
+        "------\n"
         f"{macro_list}"
     )
     return output_template

--- a/mbed_build/_internal/mbed_tools/config.py
+++ b/mbed_build/_internal/mbed_tools/config.py
@@ -114,7 +114,7 @@ def _build_legacy_output(config: Config) -> str:
     macro_list = ""
     for macro in _config_macros_sorted_by_name(config):
         if macro.value:
-            macro_list += f"{macro.name}=({macro.value})\n"
+            macro_list += f"{macro.name}={macro.value}\n"
         else:
             macro_list += f"{macro.name}\n"
 

--- a/mbed_build/_internal/mbed_tools/config.py
+++ b/mbed_build/_internal/mbed_tools/config.py
@@ -1,0 +1,124 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Write out the computed configuration for a build."""
+import json
+import pathlib
+from typing import Dict, Any
+
+import click
+from tabulate import tabulate
+
+from mbed_build._internal.config.assemble_build_config import assemble_config, BuildConfig
+
+
+@click.command(help="Print the computed configuration for a build.")
+@click.option("-m", "--mbed_target", required=True, help="A build target for an Mbed-enabled device, eg. K64F")
+@click.option(
+    "-p",
+    "--project-path",
+    type=click.Path(),
+    default=".",
+    help="Path to local Mbed project. By default is the current working directory.",
+)
+@click.option(
+    "--format",
+    type=click.Choice(["table", "json", "legacy"]),
+    default="table",
+    show_default=True,
+    help="Set output format. Default will show you the brief table format. For more detailled information use JSON format.",
+)
+def config(mbed_target: str, project_path: str, format: str) -> None:
+    """Calculates the configuration for a build and prints it out.
+
+    Each build of an Mbed project requires calculating the combined configuration
+    taken from the target definition in targets.json and mbed_lib.json files in
+    Mbed OS library and the project's own mbed_config.json config overrides file.
+
+    This command prints out the combined config taking all these sources into account.
+
+    Args:
+        mbed_target: the build target you are wanting to run your app (eg. K64F)
+        project_path: the path to the Mbed project
+        format: the format to print the resulting config data
+
+    """
+    build_config = assemble_config(mbed_target, pathlib.Path(project_path))
+    output_builders = {
+        "table": _build_tabular_output,
+        "json": _build_json_output,
+        "legacy": _build_legacy_output,
+    }
+    output = output_builders[format](build_config)
+    click.echo(output)
+
+
+def _build_tabular_output(config_data: BuildConfig) -> str:
+    parameter_table_headers = ["key", "macro name", "value"]
+
+    parameters_data = []
+    for _, option in sorted(config_data.config.options.items(), key=lambda item: item[1].key):
+        parameters_data.append([option.key, option.macro_name, option.value])
+    parameters_table = tabulate(parameters_data, parameter_table_headers)
+
+    macros_table_headers = ["name", "value"]
+    macros_data = [[macro, ""] for macro in config_data.macros]
+    macros_table = tabulate(macros_data, macros_table_headers)
+
+    output_template = (
+        f"PARAMETER CONFIGURATION\n"
+        f"-----------------------\n"
+        f"{parameters_table}\n"
+        f"\n"
+        f"MACRO CONFIGURATION\n"
+        f"-------------------\n"
+        f"{macros_table}"
+    )
+
+    return output_template
+
+
+def _build_json_output(config_data: BuildConfig) -> str:
+    config: Dict[str, Any] = {"parameters": [], "macros": []}
+
+    for _, option in sorted(config_data.config.options.items(), key=lambda item: item[1].key):
+        config["parameters"].append(
+            {
+                "key": option.key,
+                "macro_name": option.macro_name,
+                "value": option.value,
+                "help_text": option.help_text,
+                "set_by": option.set_by,
+            }
+        )
+
+    for macro in config_data.macros:
+        config["macros"].append({"name": macro})
+
+    return json.dumps(config, indent=4)
+
+
+def _build_legacy_output(config_data: BuildConfig) -> str:
+    """Output format to match that of legacy tools running mbed compile --config."""
+    parameter_list = ""
+    for _, option in sorted(config_data.config.options.items(), key=lambda item: item[1].key):
+        if option.value:
+            parameter_list += f'{option.key} = {option.value} (macro name: "{option.macro_name}")\n'
+        else:
+            parameter_list += f"{option.key} has no value\n"
+
+    macro_list = ""
+    for macro in config_data.macros:
+        macro_list += f"{macro}\n"
+
+    output_template = (
+        f"Configuration parameters\n"
+        f"------------------------\n"
+        f"{parameter_list}\n"
+        f"\n"
+        f"Macros\n"
+        f"------\n"
+        f"{macro_list}"
+    )
+    return output_template

--- a/mbed_build/_internal/mbed_tools/config.py
+++ b/mbed_build/_internal/mbed_tools/config.py
@@ -5,13 +5,13 @@
 """Write out the computed configuration for a build."""
 import json
 import pathlib
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Iterator, ItemsView
 
 import click
 from tabulate import tabulate
 
-from mbed_build._internal.config.config import Config, Option
-from mbed_build._internal.config.assemble_build_config import assemble_config, BuildConfig
+from mbed_build._internal.config.config import Config, Option, Macro
+from mbed_build._internal.config.assemble_build_config import assemble_config
 
 
 @click.command(help="Print the computed configuration for a build.")
@@ -45,26 +45,26 @@ def config(mbed_target: str, project_path: str, format: str) -> None:
         format: the format to print the resulting config data
 
     """
-    build_config = assemble_config(mbed_target, pathlib.Path(project_path))
+    config = assemble_config(mbed_target, pathlib.Path(project_path))
     output_builders = {
         "table": _build_tabular_output,
         "json": _build_json_output,
         "legacy": _build_legacy_output,
     }
-    output = output_builders[format](build_config)
+    output = output_builders[format](config)
     click.echo(output)
 
 
-def _build_tabular_output(config_data: BuildConfig) -> str:
+def _build_tabular_output(config: Config) -> str:
     parameter_table_headers = ["key", "macro name", "value"]
 
     parameters_data = []
-    for option in _config_options_sorted_by_key(config_data.config):
+    for option in _config_options_sorted_by_key(config):
         parameters_data.append([option.key, option.macro_name, option.value])
     parameters_table = tabulate(parameters_data, parameter_table_headers)
 
     macros_table_headers = ["name", "value"]
-    macros_data = [[macro, ""] for macro in config_data.macros]
+    macros_data = [[macro.name, macro.value] for macro in _config_macros_sorted_by_name(config)]
     macros_table = tabulate(macros_data, macros_table_headers)
 
     output_template = (
@@ -80,11 +80,11 @@ def _build_tabular_output(config_data: BuildConfig) -> str:
     return output_template
 
 
-def _build_json_output(config_data: BuildConfig) -> str:
-    config: Dict[str, Any] = {"parameters": [], "macros": []}
+def _build_json_output(config: Config) -> str:
+    config_object: Dict[str, Any] = {"parameters": [], "macros": []}
 
-    for option in _config_options_sorted_by_key(config_data.config):
-        config["parameters"].append(
+    for option in _config_options_sorted_by_key(config):
+        config_object["parameters"].append(
             {
                 "key": option.key,
                 "macro_name": option.macro_name,
@@ -94,24 +94,29 @@ def _build_json_output(config_data: BuildConfig) -> str:
             }
         )
 
-    for macro in config_data.macros:
-        config["macros"].append({"name": macro})
+    for macro in _config_macros_sorted_by_name(config):
+        config_object["macros"].append(
+            {"name": macro.name, "value": macro.value, "set_by": macro.set_by,}
+        )
 
-    return json.dumps(config, indent=4)
+    return json.dumps(config_object, indent=4)
 
 
-def _build_legacy_output(config_data: BuildConfig) -> str:
+def _build_legacy_output(config: Config) -> str:
     """Output format to match that of legacy tools running mbed compile --config."""
     parameter_list = ""
-    for option in _config_options_sorted_by_key(config_data.config):
+    for option in _config_options_sorted_by_key(config):
         if option.value:
             parameter_list += f'{option.key} = {option.value} (macro name: "{option.macro_name}")\n'
         else:
             parameter_list += f"{option.key} has no value\n"
 
     macro_list = ""
-    for macro in config_data.macros:
-        macro_list += f"{macro}\n"
+    for macro in _config_macros_sorted_by_name(config):
+        if macro.value:
+            macro_list += f"{macro.name}=({macro.value})\n"
+        else:
+            macro_list += f"{macro.name}\n"
 
     output_template = (
         "Configuration parameters\n"
@@ -125,7 +130,13 @@ def _build_legacy_output(config_data: BuildConfig) -> str:
     return output_template
 
 
+def _extract_values_from_dict(items: ItemsView[str, Any]) -> Iterator[Any]:
+    return map(lambda item: item[1], items)
+
+
 def _config_options_sorted_by_key(config: Config) -> List[Option]:
-    extracted_options = map(lambda item: item[1], config.options.items())
-    sorted_options = sorted(extracted_options, key=lambda item: item.key)
-    return sorted_options
+    return sorted(_extract_values_from_dict(config.options.items()), key=lambda item: item.key)
+
+
+def _config_macros_sorted_by_name(config: Config) -> List[Macro]:
+    return sorted(_extract_values_from_dict(config.macros.items()), key=lambda item: item.name)

--- a/mbed_build/_internal/mbed_tools/config.py
+++ b/mbed_build/_internal/mbed_tools/config.py
@@ -95,9 +95,7 @@ def _build_json_output(config: Config) -> str:
         )
 
     for macro in _config_macros_sorted_by_name(config):
-        config_object["macros"].append(
-            {"name": macro.name, "value": macro.value, "set_by": macro.set_by}
-        )
+        config_object["macros"].append({"name": macro.name, "value": macro.value, "set_by": macro.set_by})
 
     return json.dumps(config_object, indent=4)
 

--- a/mbed_build/_internal/mbed_tools/config.py
+++ b/mbed_build/_internal/mbed_tools/config.py
@@ -27,7 +27,7 @@ from mbed_build._internal.config.assemble_build_config import assemble_config, B
     type=click.Choice(["table", "json", "legacy"]),
     default="table",
     show_default=True,
-    help="Set output format. Default will show you the brief table format. For more detailled information use JSON format.",
+    help="Set output format. To see maximum info use JSON format.",
 )
 def config(mbed_target: str, project_path: str, format: str) -> None:
     """Calculates the configuration for a build and prints it out.

--- a/mbed_build/mbed_tools.py
+++ b/mbed_build/mbed_tools.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Integration with https://github.com/ARMmbed/mbed-tools."""
+from mbed_build._internal.mbed_tools.config import config
 from mbed_build._internal.mbed_tools.export import export
 
-cli = export
+config = config
+export = export

--- a/mbed_build/mbed_tools.py
+++ b/mbed_build/mbed_tools.py
@@ -6,5 +6,7 @@
 from mbed_build._internal.mbed_tools.config import config
 from mbed_build._internal.mbed_tools.export import export
 
+cli = export
+
 config = config
 export = export

--- a/news/20200428.feature
+++ b/news/20200428.feature
@@ -1,0 +1,1 @@
+Add config command.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     description="Core Build Tools for Mbed OS",
     keywords="Arm Mbed OS MbedOS build compile link cmake",
     include_package_data=True,
-    install_requires=["python-dotenv", "Click==7.0", "Jinja2", "mbed-targets", "mbed-tools-lib"],
+    install_requires=["python-dotenv", "Click==7.0", "Jinja2", "mbed-targets", "mbed-tools-lib", "tabulate"],
     license="Apache 2.0",
     long_description_content_type="text/markdown",
     long_description=long_description,

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -4,8 +4,7 @@
 #
 import factory
 
-from mbed_build._internal.config.assemble_build_config import BuildConfig
-from mbed_build._internal.config.config import Config, Option
+from mbed_build._internal.config.config import Config, Option, Macro
 from mbed_build._internal.config.source import Source
 
 
@@ -31,16 +30,18 @@ class OptionFactory(factory.Factory):
     key = "key"
 
 
+class MacroFactory(factory.Factory):
+    class Meta:
+        model = Macro
+
+    value = "0"
+    name = "A_MACRO"
+    set_by = "source"
+
+
 class ConfigFactory(factory.Factory):
     class Meta:
         model = Config
 
     options = factory.Dict({})
-
-
-class BuildConfigFactory(factory.Factory):
-    class Meta:
-        model = BuildConfig
-
-    config = factory.SubFactory(ConfigFactory)
-    macros = set()
+    macros = factory.Dict({})

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -4,6 +4,8 @@
 #
 import factory
 
+from mbed_build._internal.config.assemble_build_config import BuildConfig
+from mbed_build._internal.config.config import Config, Option
 from mbed_build._internal.config.source import Source
 
 
@@ -16,3 +18,29 @@ class SourceFactory(factory.Factory):
     config_overrides = factory.Dict({})
     cumulative_overrides = factory.Dict({})
     macros = factory.List([])
+
+
+class OptionFactory(factory.Factory):
+    class Meta:
+        model = Option
+
+    value = "0"
+    macro_name = "MACRO_NAME"
+    help_text = factory.Faker("text")
+    set_by = "libname"
+    key = "key"
+
+
+class ConfigFactory(factory.Factory):
+    class Meta:
+        model = Config
+
+    options = factory.Dict({})
+
+
+class BuildConfigFactory(factory.Factory):
+    class Meta:
+        model = BuildConfig
+
+    config = factory.SubFactory(ConfigFactory)
+    macros = set()

--- a/tests/_internal/mbed_tools/test_config_command.py
+++ b/tests/_internal/mbed_tools/test_config_command.py
@@ -114,7 +114,7 @@ class TestBuildLegacyOutput(TestCase):
             "\n"
             "Macros\n"
             "------\n"
-            f"{macro.name}=({macro.value})\n"
+            f"{macro.name}={macro.value}\n"
         )
 
         result = _build_legacy_output(config)

--- a/tests/_internal/mbed_tools/test_config_command.py
+++ b/tests/_internal/mbed_tools/test_config_command.py
@@ -92,7 +92,7 @@ class TestBuildJSONOutput(TestCase):
                     "set_by": option.set_by,
                 }
             ],
-            "macros": [{"name": macro.name, "value": macro.value, "set_by": macro.set_by,}],
+            "macros": [{"name": macro.name, "value": macro.value, "set_by": macro.set_by}],
         }
 
         result = _build_json_output(config)

--- a/tests/_internal/mbed_tools/test_config_command.py
+++ b/tests/_internal/mbed_tools/test_config_command.py
@@ -28,7 +28,7 @@ class TestConfig(TestCase):
         result = runner.invoke(config, ["-m", self.mbed_target, "-p", self.project_path])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.output, _build_tabular_output(assemble_config.return_value) + "\n")
+        self.assertIn(_build_tabular_output(assemble_config.return_value), result.output)
         assemble_config.assert_called_once_with(self.mbed_target, pathlib.Path(self.project_path))
 
     def test_config_json(self, assemble_config):
@@ -36,7 +36,7 @@ class TestConfig(TestCase):
         result = runner.invoke(config, ["-m", self.mbed_target, "-p", self.project_path, "--format", "json"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.output, _build_json_output(assemble_config.return_value) + "\n")
+        self.assertIn(_build_json_output(assemble_config.return_value), result.output)
         assemble_config.assert_called_once_with(self.mbed_target, pathlib.Path(self.project_path))
 
     def test_config_legacy(self, assemble_config):
@@ -46,7 +46,7 @@ class TestConfig(TestCase):
         )
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.output, _build_legacy_output(assemble_config.return_value) + "\n")
+        self.assertIn(_build_legacy_output(assemble_config.return_value), result.output)
         assemble_config.assert_called_once_with(self.mbed_target, pathlib.Path(self.project_path))
 
 

--- a/tests/_internal/mbed_tools/test_config_command.py
+++ b/tests/_internal/mbed_tools/test_config_command.py
@@ -1,0 +1,130 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+import json
+import pathlib
+from unittest import TestCase, mock
+
+from click.testing import CliRunner
+from tabulate import tabulate
+
+from mbed_build._internal.mbed_tools.config import (
+    config,
+    _build_tabular_output,
+    _build_json_output,
+    _build_legacy_output,
+)
+from tests._internal.config.factories import BuildConfigFactory, OptionFactory
+
+
+@mock.patch("mbed_build._internal.mbed_tools.config._build_legacy_output")
+@mock.patch("mbed_build._internal.mbed_tools.config._build_json_output")
+@mock.patch("mbed_build._internal.mbed_tools.config._build_tabular_output")
+@mock.patch("mbed_build._internal.mbed_tools.config.assemble_config")
+class TestConfig(TestCase):
+    mbed_target = "K64F"
+    project_path = "somewhere"
+
+    def test_config_table(self, assemble_config, build_tabular_output, build_json_output, build_legacy_output):
+        runner = CliRunner()
+        result = runner.invoke(config, ["-m", self.mbed_target, "-p", self.project_path])
+
+        self.assertEqual(result.exit_code, 0)
+        assemble_config.assert_called_once_with(self.mbed_target, pathlib.Path(self.project_path))
+        build_tabular_output.assert_called_once_with(assemble_config.return_value)
+        build_json_output.assert_not_called()
+        build_legacy_output.assert_not_called()
+
+    def test_config_json(self, assemble_config, build_tabular_output, build_json_output, build_legacy_output):
+        runner = CliRunner()
+        result = runner.invoke(config, ["-m", self.mbed_target, "-p", self.project_path, "--format", "json"])
+
+        self.assertEqual(result.exit_code, 0)
+        assemble_config.assert_called_once_with(self.mbed_target, pathlib.Path(self.project_path))
+        build_tabular_output.assert_not_called()
+        build_json_output.assert_called_once_with(assemble_config.return_value)
+        build_legacy_output.assert_not_called()
+
+    def test_config_legacy(self, assemble_config, build_tabular_output, build_json_output, build_legacy_output):
+        runner = CliRunner()
+        result = runner.invoke(
+            config, ["-m", self.mbed_target, "-p", self.project_path, "--format", "json", "--format", "legacy"]
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        assemble_config.assert_called_once_with(self.mbed_target, pathlib.Path(self.project_path))
+        build_tabular_output.assert_not_called()
+        build_json_output.assert_not_called()
+        build_legacy_output.assert_called_once_with(assemble_config.return_value)
+
+
+class TestBuildTabularOutput(TestCase):
+    def test_builds(self):
+        option = OptionFactory()
+        macro = "I_AM_A_MACRO"
+        config_data = BuildConfigFactory()
+        config_data.config.options[option.key] = option
+        config_data.macros.add(macro)
+
+        parameters_table = tabulate([[option.key, option.macro_name, option.value]], ["key", "macro name", "value"])
+        macros_table = tabulate([[macro, " "]], ["name", "value"])
+        expected_output = (
+            f"PARAMETER CONFIGURATION\n"
+            f"-----------------------\n"
+            f"{parameters_table}\n"
+            f"\n"
+            f"MACRO CONFIGURATION\n"
+            f"-------------------\n"
+            f"{macros_table}"
+        )
+
+        result = _build_tabular_output(config_data)
+        self.assertEqual(result, expected_output)
+
+
+class TestBuildJSONOutput(TestCase):
+    def test_builds(self):
+        option = OptionFactory()
+        macro = "I_AM_A_MACRO"
+        config_data = BuildConfigFactory()
+        config_data.config.options[option.key] = option
+        config_data.macros.add(macro)
+
+        expected_config = {
+            "parameters": [
+                {
+                    "key": option.key,
+                    "macro_name": option.macro_name,
+                    "value": option.value,
+                    "help_text": option.help_text,
+                    "set_by": option.set_by,
+                }
+            ],
+            "macros": [{"name": macro}],
+        }
+
+        result = _build_json_output(config_data)
+        self.assertEqual(result, json.dumps(expected_config, indent=4))
+
+
+class TestBuildLegacyOutput(TestCase):
+    def test_builds(self):
+        option = OptionFactory()
+        macro = "I_AM_A_MACRO"
+        config_data = BuildConfigFactory()
+        config_data.config.options[option.key] = option
+        config_data.macros.add(macro)
+
+        expected_output = (
+            f"Configuration parameters\n"
+            f"------------------------\n"
+            f'{option.key} = {option.value} (macro name: "{option.macro_name}")\n\n'
+            f"\n"
+            f"Macros\n"
+            f"------\n"
+            f"{macro}\n"
+        )
+
+        result = _build_legacy_output(config_data)
+        self.assertEqual(result, expected_output)

--- a/tests/_internal/mbed_tools/test_config_command.py
+++ b/tests/_internal/mbed_tools/test_config_command.py
@@ -132,7 +132,7 @@ class TestBuildLegacyOutput(TestCase):
         expected_output = (
             "Configuration parameters\n"
             "------------------------\n"
-            f'{option.key} has no value\n\n'
+            f"{option.key} has no value\n\n"
             "\n"
             "Macros\n"
             "------\n"

--- a/tests/_internal/mbed_tools/test_config_command.py
+++ b/tests/_internal/mbed_tools/test_config_command.py
@@ -70,12 +70,12 @@ class TestBuildTabularOutput(TestCase):
         parameters_table = tabulate([[option.key, option.macro_name, option.value]], ["key", "macro name", "value"])
         macros_table = tabulate([[macro, " "]], ["name", "value"])
         expected_output = (
-            f"PARAMETER CONFIGURATION\n"
-            f"-----------------------\n"
+            "PARAMETER CONFIGURATION\n"
+            "-----------------------\n"
             f"{parameters_table}\n"
-            f"\n"
-            f"MACRO CONFIGURATION\n"
-            f"-------------------\n"
+            "\n"
+            "MACRO CONFIGURATION\n"
+            "-------------------\n"
             f"{macros_table}"
         )
 
@@ -117,12 +117,12 @@ class TestBuildLegacyOutput(TestCase):
         config_data.macros.add(macro)
 
         expected_output = (
-            f"Configuration parameters\n"
-            f"------------------------\n"
+            "Configuration parameters\n"
+            "------------------------\n"
             f'{option.key} = {option.value} (macro name: "{option.macro_name}")\n\n'
-            f"\n"
-            f"Macros\n"
-            f"------\n"
+            "\n"
+            "Macros\n"
+            "------\n"
             f"{macro}\n"
         )
 

--- a/tests/_internal/mbed_tools/test_config_command.py
+++ b/tests/_internal/mbed_tools/test_config_command.py
@@ -119,3 +119,25 @@ class TestBuildLegacyOutput(TestCase):
 
         result = _build_legacy_output(config)
         self.assertEqual(result, expected_output)
+
+    def test_builds_value_none(self):
+        option = OptionFactory()
+        option.value = None
+        macro = MacroFactory()
+        macro.value = None
+        config = ConfigFactory()
+        config.options[option.key] = option
+        config.macros[macro.name] = macro
+
+        expected_output = (
+            "Configuration parameters\n"
+            "------------------------\n"
+            f'{option.key} has no value\n\n'
+            "\n"
+            "Macros\n"
+            "------\n"
+            f"{macro.name}\n"
+        )
+
+        result = _build_legacy_output(config)
+        self.assertEqual(result, expected_output)

--- a/tests/test_mbed_tools.py
+++ b/tests/test_mbed_tools.py
@@ -5,9 +5,15 @@
 from unittest import TestCase
 
 from mbed_build._internal.mbed_tools.export import export
-from mbed_build.mbed_tools import cli
+from mbed_build._internal.mbed_tools.config import config
+from mbed_build import mbed_tools
 
 
-class TestCli(TestCase):
+class TestConfig(TestCase):
+    def test_aliases_config(self):
+        self.assertEqual(mbed_tools.config, config)
+
+
+class TestExport(TestCase):
     def test_aliases_export(self):
-        self.assertEqual(cli, export)
+        self.assertEqual(mbed_tools.export, export)


### PR DESCRIPTION
### Description

Add config command. It prints configuration settings in three formats - tabular, json and legacy (legacy should only be used for checking output against our test archive).

I haven't pulled out any shared code into mbed-tools-libs since there was no particular overlapping logic with mbed-devices. The way to keep consistent is just to make sure we use `tabulate` for tables in both places in the same mode. Still unsure if that is worth abstracting in some way. What do you think? We use the same libraries across packages elsewhere and don't abstract them.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
