### PR TITLE
📌Add a version specifier to the dependencies for Mbed packages

### DIFF
--- a/news/20200428.misc
+++ b/news/20200428.misc
@@ -1,0 +1,1 @@
+Add a version specifier to the dependencies for Mbed packages

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,14 @@ setup(
     description="Core Build Tools for Mbed OS",
     keywords="Arm Mbed OS MbedOS build compile link cmake",
     include_package_data=True,
-    install_requires=["python-dotenv", "Click==7.0", "Jinja2", "mbed-targets", "mbed-tools-lib", "tabulate"],
+    install_requires=[
+        "python-dotenv",
+        "Click==7.0",
+        "Jinja2",
+        "mbed-targets~=1.0",
+        "mbed-tools-lib~=1.2",
+        "tabulate"
+    ],
     license="Apache 2.0",
     long_description_content_type="text/markdown",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,7 @@ setup(
     description="Core Build Tools for Mbed OS",
     keywords="Arm Mbed OS MbedOS build compile link cmake",
     include_package_data=True,
-    install_requires=[
-        "python-dotenv",
-        "Click==7.0",
-        "Jinja2",
-        "mbed-targets~=1.0",
-        "mbed-tools-lib~=1.2",
-        "tabulate"
-    ],
+    install_requires=["python-dotenv", "Click==7.0", "Jinja2", "mbed-targets~=1.0", "mbed-tools-lib~=1.2", "tabulate"],
     license="Apache 2.0",
     long_description_content_type="text/markdown",
     long_description=long_description,


### PR DESCRIPTION
### Description

So that we can make future breaking changes to Mbed packages relied on by mbed-tools, a version specifier is set for each Mbed package. This simplifies development, allowing internal interfaces to be changed while ensuring that new tools will not be installed if the are not compatible.

### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
