### PR TITLE
♻️ Configuration assembly refactor sources

### DIFF
--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, Optional
 
 from mbed_build._internal.config.source import Source
+from mbed_build._internal.config.cumulative_data import ALL_CUMULATIVE_FIELDS
 
 
 @dataclass
@@ -91,7 +92,7 @@ class Config:
     """Representation of config attributes assembled during Source parsing.
 
     Attributes:
-        options: Options parsed from "config" and "config_overrides" sections of *.json files
+        options: Options parsed from "config" and "target_overrides" sections of *.json files
         macros: Macros parsed from "macros" section of mbed_lib.json and mbed_app.json file
     """
 
@@ -105,7 +106,9 @@ class Config:
         for source in sources:
             for key, value in source.config.items():
                 _create_config_option(config, key, value, source)
-            for key, value in source.config_overrides.items():
+            for key, value in source.overrides.items():
+                if key in ALL_CUMULATIVE_FIELDS:
+                    continue
                 _update_config_option(config, key, value, source)
             for value in source.macros:
                 _create_macro(config, value, source)

--- a/mbed_build/_internal/config/cumulative_data.py
+++ b/mbed_build/_internal/config/cumulative_data.py
@@ -29,8 +29,9 @@ class CumulativeData:
         """Interrogate each Source in turn to create final CumulativeData."""
         data = CumulativeData()
         for source in sources:
-            for key, value in source.cumulative_overrides.items():
-                _modify_field(data, key, value)
+            for key, value in source.overrides.items():
+                if key in ALL_CUMULATIVE_FIELDS:
+                    _modify_field(data, key, value)
         return data
 
 

--- a/mbed_build/_internal/config/source.py
+++ b/mbed_build/_internal/config/source.py
@@ -6,10 +6,9 @@
 from dataclasses import dataclass
 import json
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Iterable
 
 from mbed_targets import get_target_by_board_type
-from mbed_build._internal.config.cumulative_data import ALL_CUMULATIVE_FIELDS
 
 
 @dataclass
@@ -26,8 +25,7 @@ class Source:
 
     human_name: str
     config: dict
-    config_overrides: dict
-    cumulative_overrides: dict
+    overrides: dict
     macros: Iterable[str]
 
     @classmethod
@@ -66,20 +64,13 @@ class Source:
         config = file_contents.get("config", {})
         config = _namespace_data(config, namespace)
 
-        target_overrides = file_contents.get("target_overrides", {})
-        target_specific_overrides = _filter_target_overrides(target_overrides, target_labels)
-        target_specific_overrides = _namespace_data(target_specific_overrides, namespace)
-        config_overrides, cumulative_overrides = _split_target_overrides_by_type(target_specific_overrides)
+        overrides = file_contents.get("target_overrides", {})
+        target_specific_overrides = _filter_target_overrides(overrides, target_labels)
+        namespaced_overrides = _namespace_data(target_specific_overrides, namespace)
 
         macros = file_contents.get("macros", [])
 
-        return cls(
-            human_name=f"File: {file_name}",
-            config=config,
-            cumulative_overrides=cumulative_overrides,
-            config_overrides=config_overrides,
-            macros=macros,
-        )
+        return cls(human_name=f"File: {file_name}", config=config, overrides=namespaced_overrides, macros=macros)
 
     @classmethod
     def from_target(cls, mbed_target: str, mbed_program_directory: Path) -> "Source":
@@ -88,18 +79,17 @@ class Source:
         namespace = "target"
         config = _namespace_data(target.config, namespace)
 
-        cumulative_overrides = {
+        overrides = {
             "features": target.features,
             "components": target.components,
             "labels": target.labels,
         }
-        cumulative_overrides = _namespace_data(cumulative_overrides, namespace)
+        namespaced_overrides = _namespace_data(overrides, namespace)
 
         return cls(
             human_name=f"mbed_target.Target for {mbed_target}",
             config=config,
-            config_overrides={},
-            cumulative_overrides=cumulative_overrides,
+            overrides=namespaced_overrides,
             macros=[],
         )
 
@@ -114,18 +104,6 @@ def _filter_target_overrides(data: dict, allowed_labels: Iterable[str]) -> dict:
         if target_label == "*" or target_label in allowed_labels:
             flattened.update(overrides)
     return flattened
-
-
-def _split_target_overrides_by_type(data: dict) -> Tuple[dict, dict]:
-    """Split target override data into config overrides and cumulative overrides."""
-    config_overrides = {}
-    cumulative_overrides = {}
-    for key, value in data.items():
-        if key in ALL_CUMULATIVE_FIELDS:
-            cumulative_overrides[key] = value
-        else:
-            config_overrides[key] = value
-    return config_overrides, cumulative_overrides
 
 
 def _namespace_data(data: dict, namespace: str) -> dict:

--- a/news/2020042801.misc
+++ b/news/2020042801.misc
@@ -1,0 +1,1 @@
+Refactor Source

--- a/tests/_internal/config/factories.py
+++ b/tests/_internal/config/factories.py
@@ -14,8 +14,7 @@ class SourceFactory(factory.Factory):
 
     human_name = factory.Faker("name")
     config = factory.Dict({})
-    config_overrides = factory.Dict({})
-    cumulative_overrides = factory.Dict({})
+    overrides = factory.Dict({})
     macros = factory.List([])
 
 

--- a/tests/_internal/config/test_assemble_build_config.py
+++ b/tests/_internal/config/test_assemble_build_config.py
@@ -53,7 +53,7 @@ class TestAssembleConfig(TestCase):
 
 class TestAssembleConfigFromSourcesAndLibFiles(TestCase):
     def test_assembles_config_using_all_relevant_files(self):
-        target_source = SourceFactory(config={"target.foo": "foo"}, cumulative_overrides={"target.labels": ["A"]})
+        target_source = SourceFactory(config={"target.foo": "foo"}, overrides={"target.labels": ["A"]})
         mbed_lib_files = [
             {
                 "path": Path("TARGET_A", "mbed_lib.json"),

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -11,7 +11,7 @@ from tests._internal.config.factories import SourceFactory
 class TestConfigFromSources(TestCase):
     def test_builds_config_from_sources(self):
         source_a = SourceFactory(config={"bool": True, "string": "foo"}, macros=["MACRO_A=A"])
-        source_b = SourceFactory(config={"number": 1}, config_overrides={"bool": False}, macros=["MACRO_B=B"])
+        source_b = SourceFactory(config={"number": 1}, overrides={"bool": False}, macros=["MACRO_B=B"])
 
         config = Config.from_sources([source_a, source_b])
 
@@ -31,7 +31,7 @@ class TestConfigFromSources(TestCase):
 
     def test_raises_when_trying_to_override_unset_option(self):
         source_a = SourceFactory(config={"bool": True})
-        source_b = SourceFactory(config_overrides={"string": "hello"})
+        source_b = SourceFactory(overrides={"string": "hello"})
 
         with self.assertRaises(ValueError):
             Config.from_sources([source_a, source_b])
@@ -45,7 +45,7 @@ class TestConfigFromSources(TestCase):
 
     def test_keeps_old_option_data(self):
         source_a = SourceFactory(config={"bool": {"help": "A simple bool", "value": True}})
-        source_b = SourceFactory(config_overrides={"bool": False})
+        source_b = SourceFactory(overrides={"bool": False})
 
         config = Config.from_sources([source_a, source_b])
 

--- a/tests/_internal/config/test_cumulative_data.py
+++ b/tests/_internal/config/test_cumulative_data.py
@@ -13,9 +13,9 @@ class TestCumulativeDataFromSources(TestCase):
     def test_assembles_metadata_from_sources(self):
         for field in fields(CumulativeData):
             with self.subTest(f"Assemble {field.name}"):
-                source_a = SourceFactory(cumulative_overrides={f"target.{field.name}": ["FOO"]})
-                source_b = SourceFactory(cumulative_overrides={f"target.{field.name}_add": ["BAR", "BAZ"]})
-                source_c = SourceFactory(cumulative_overrides={f"target.{field.name}_remove": ["BAR"]})
+                source_a = SourceFactory(overrides={f"target.{field.name}": ["FOO"]})
+                source_b = SourceFactory(overrides={f"target.{field.name}_add": ["BAR", "BAZ"]})
+                source_c = SourceFactory(overrides={f"target.{field.name}_remove": ["BAR"]})
 
                 config_cumulative_data = CumulativeData.from_sources([source_a, source_b, source_c])
 

--- a/tests/_internal/config/test_source.py
+++ b/tests/_internal/config/test_source.py
@@ -33,8 +33,12 @@ class TestSource(TestCase):
             Source(
                 human_name=f"File: {file}",
                 config={"foo.a-number": 123, "foo.a-bool": {"help": "Simply a boolean", "value": True}},
-                config_overrides={"foo.a-number": 456, "foo.a-bool": False, "other-lib.something-else": "blah"},
-                cumulative_overrides={"target.features_add": ["FOO"]},
+                overrides={
+                    "foo.a-number": 456,
+                    "foo.a-bool": False,
+                    "other-lib.something-else": "blah",
+                    "target.features_add": ["FOO"],
+                },
                 macros=["MACRO=1"],
             ),
         )
@@ -60,8 +64,12 @@ class TestSource(TestCase):
             Source(
                 human_name=f"File: {file}",
                 config={"app.a-bool": False, "app.a-number": {"help": "Simply a number", "value": 0}},
-                config_overrides={"app.a-number": 2, "app.a-bool": True, "some-lib.something-else": "blah"},
-                cumulative_overrides={"target.features_add": ["HAT"]},
+                overrides={
+                    "app.a-number": 2,
+                    "app.a-bool": True,
+                    "some-lib.something-else": "blah",
+                    "target.features_add": ["HAT"],
+                },
                 macros=["SOME_MACRO=2"],
             ),
         )
@@ -86,8 +94,7 @@ class TestSource(TestCase):
             Source(
                 human_name=f"mbed_target.Target for {mbed_target}",
                 config={"target.foo": "bar", "target.bool": True},
-                config_overrides={},
-                cumulative_overrides={
+                overrides={
                     "target.features": target.features,
                     "target.components": target.components,
                     "target.labels": target.labels,


### PR DESCRIPTION
### Description

Sources should know as little as possible.

Previously, upon building a Source it'd look into what `cumulative_data.CUMULATIVE_OVERRIDE` is and group the parsed data accordingly. `CumulativeData` would then parse the source, knowing where to look for it. 
While working on _bootloader overrides_, I decided this is not that great and should happen where the data is parsed instead of where it's read.
The side effect of that is that `Config` parsing will now need to know to ignore certain keys. While not great either, I think it's clearer and makes for more transparent `Source`s.

---

As I branched of my previous work, I'm targeting `configuration-assembly-app-layer` for the sake of smaller diff. Once `mbed-targets` is merged and I can close https://github.com/ARMmbed/mbed-build/pull/35, I will change the target. 😅 



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
