### PR TITLE
✨Configuration assembly bootloader overrides

### DIFF
--- a/mbed_build/_internal/config/bootloader_overrides.py
+++ b/mbed_build/_internal/config/bootloader_overrides.py
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Ability to parse bootloader overrides from Sources."""
+from dataclasses import dataclass, field, fields
+from typing import Any, Iterable, Optional
+
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mbed_build._internal.config.source import Source
+
+
+@dataclass
+class BootloaderOverride:
+    """Representation of a bootloader override."""
+
+    value: Any
+    name: str
+    set_by: str
+
+
+@dataclass
+class BootloaderOverrides:
+    """Representation of cumulative attributes assembled during Source parsing."""
+
+    # delivery overrides
+    deliver_to_target: Optional[BootloaderOverride] = field(default=None)
+    deliver_artifacts: Optional[BootloaderOverride] = field(default=None)
+    delivery_dir: Optional[BootloaderOverride] = field(default=None)
+
+    # rom overrides managed BL
+    bootloader_img: Optional[BootloaderOverride] = field(default=None)
+    restrict_size: Optional[BootloaderOverride] = field(default=None)
+    header_format: Optional[BootloaderOverride] = field(default=None)
+    header_offset: Optional[BootloaderOverride] = field(default=None)
+    app_offset: Optional[BootloaderOverride] = field(default=None)
+    # rom overrides unmanaged BL
+    mbed_app_start: Optional[BootloaderOverride] = field(default=None)
+    mbed_app_size: Optional[BootloaderOverride] = field(default=None)
+    # rom overrides managed/unmanaged BL
+    mbed_rom_start: Optional[BootloaderOverride] = field(default=None)
+    mbed_rom_size: Optional[BootloaderOverride] = field(default=None)
+
+    # ram overrides
+    mbed_ram_start: Optional[BootloaderOverride] = field(default=None)
+    mbed_ram_size: Optional[BootloaderOverride] = field(default=None)
+
+    @classmethod
+    def from_sources(cls, sources: Iterable["Source"]) -> "BootloaderOverrides":
+        """Interrogate each Source in turn to create BootloaderOverrides."""
+        data = BootloaderOverrides()
+        for source in sources:
+            for key, value in source.overrides.items():
+                if key in BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE:
+                    key_without_prefix = key[len("target.") :]
+                    setattr(
+                        data,
+                        key_without_prefix,
+                        BootloaderOverride(name=key_without_prefix, value=value, set_by=source.human_name),
+                    )
+        return data
+
+
+_BOOTLOADER_OVERRIDE_FIELDS = [f.name for f in fields(BootloaderOverrides)]
+BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE = [f"target.{f}" for f in _BOOTLOADER_OVERRIDE_FIELDS]

--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, Optional
 
 from mbed_build._internal.config.source import Source
-from mbed_build._internal.config.cumulative_data import ALL_CUMULATIVE_FIELDS
+from mbed_build._internal.config.cumulative_data import CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE
+from mbed_build._internal.config.bootloader_overrides import BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE
 
 
 @dataclass
@@ -87,6 +88,9 @@ def _build_macro_name(config_key: str) -> str:
     return f"MBED_CONF_{sanitised_config_key}"
 
 
+IGNORED_OVERRIDE_KEYS_IN_SOURCE = CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE + BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE
+
+
 @dataclass
 class Config:
     """Representation of config attributes assembled during Source parsing.
@@ -107,7 +111,7 @@ class Config:
             for key, value in source.config.items():
                 _create_config_option(config, key, value, source)
             for key, value in source.overrides.items():
-                if key in ALL_CUMULATIVE_FIELDS:
+                if key in IGNORED_OVERRIDE_KEYS_IN_SOURCE:
                     continue
                 _update_config_option(config, key, value, source)
             for value in source.macros:

--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -63,29 +63,20 @@ class Option:
             return cls(
                 key=key,
                 value=data.get("value"),
-                macro_name=data.get("macro_name", _build_macro_name(key)),
+                macro_name=data.get("macro_name", _build_option_macro_name(key)),
                 help_text=data.get("help"),
                 set_by=source.human_name,
             )
         else:
-            return cls(value=data, key=key, macro_name=_build_macro_name(key), help_text=None, set_by=source.human_name)
+            return cls(
+                value=data, key=key, macro_name=_build_option_macro_name(key), help_text=None, set_by=source.human_name
+            )
 
     def set_value(self, value: Any, source: Source) -> "Option":
         """Mutate self with new value."""
         self.value = value
         self.set_by = source.human_name
         return self
-
-
-def _build_macro_name(config_key: str) -> str:
-    """Build macro name for configuration key.
-
-    All configuration variables require a macro name, so that they can be referenced in a header file.
-    Some values in config define "macro_name", some don't. This helps generate consistent macro names
-    for the latter.
-    """
-    sanitised_config_key = config_key.replace(".", "_").replace("-", "_").upper()
-    return f"MBED_CONF_{sanitised_config_key}"
 
 
 IGNORED_OVERRIDE_KEYS_IN_SOURCE = CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE + BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE
@@ -132,6 +123,17 @@ def _update_config_option(config: Config, key: str, value: Any, source: Source) 
             f" Attempting to set '{key}' to '{value}' in '{source.human_name}'."
         )
     config.options[key].set_value(value, source)
+
+
+def _build_option_macro_name(config_key: str) -> str:
+    """Build macro name for configuration key.
+
+    All configuration variables require a macro name, so that they can be referenced in a header file.
+    Some values in config define "macro_name", some don't. This helps generate consistent macro names
+    for the latter.
+    """
+    sanitised_config_key = config_key.replace(".", "_").replace("-", "_").upper()
+    return f"MBED_CONF_{sanitised_config_key}"
 
 
 def _create_macro(config: Config, macro_str: str, source: Source) -> None:

--- a/mbed_build/_internal/config/cumulative_data.py
+++ b/mbed_build/_internal/config/cumulative_data.py
@@ -30,7 +30,7 @@ class CumulativeData:
         data = CumulativeData()
         for source in sources:
             for key, value in source.overrides.items():
-                if key in ALL_CUMULATIVE_FIELDS:
+                if key in CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE:
                     _modify_field(data, key, value)
         return data
 
@@ -47,18 +47,18 @@ def _modify_field(data: CumulativeData, key: str, value: Any) -> None:
     setattr(data, key, new_value)
 
 
-CUMULATIVE_FIELDS = [f.name for f in fields(CumulativeData)]
-PREFIXED_CUMULATIVE_FIELDS = [f"target.{f}" for f in CUMULATIVE_FIELDS]
-ALL_CUMULATIVE_FIELDS = PREFIXED_CUMULATIVE_FIELDS + [
-    f"{attr}_{suffix}" for attr, suffix in itertools.product(PREFIXED_CUMULATIVE_FIELDS, ["add", "remove"])
+_CUMULATIVE_FIELDS = [f.name for f in fields(CumulativeData)]
+_PREFIXED_CUMULATIVE_FIELDS = [f"target.{f}" for f in _CUMULATIVE_FIELDS]
+CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE = _PREFIXED_CUMULATIVE_FIELDS + [
+    f"{attr}_{suffix}" for attr, suffix in itertools.product(_PREFIXED_CUMULATIVE_FIELDS, ["add", "remove"])
 ]
 
 
 def _extract_target_modifier_data(key: str) -> Tuple[str, str]:
     regex = fr"""
-            (?P<key>{'|'.join(CUMULATIVE_FIELDS)}) # attribute name (one of ACCUMULATING_OVERRIDES)
-            _?                                     # separator
-            (?P<modifier>(add|remove)?)            # modifier (add, remove or empty)
+            (?P<key>{'|'.join(_CUMULATIVE_FIELDS)}) # attribute name (one of ACCUMULATING_OVERRIDES)
+            _?                                      # separator
+            (?P<modifier>(add|remove)?)             # modifier (add, remove or empty)
     """
     match = re.search(regex, key, re.VERBOSE)
     if not match:

--- a/news/20200429.feature
+++ b/news/20200429.feature
@@ -1,0 +1,1 @@
+Parse bootloader overrides

--- a/tests/_internal/config/test_bootloader_overrides.py
+++ b/tests/_internal/config/test_bootloader_overrides.py
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+from dataclasses import fields
+from unittest import TestCase
+
+from mbed_build._internal.config.bootloader_overrides import BootloaderOverrides, BootloaderOverride
+from tests._internal.config.factories import SourceFactory
+
+
+class TestCumulativeDataFromSources(TestCase):
+    def test_assembles_metadata_from_sources(self):
+        for field in fields(BootloaderOverrides):
+            with self.subTest(f"Assemble {field.name}"):
+                source = SourceFactory(overrides={f"target.{field.name}": ["FOO"]})
+
+                bootloader_overrides = BootloaderOverrides.from_sources([source])
+
+                self.assertEqual(
+                    getattr(bootloader_overrides, field.name),
+                    BootloaderOverride(set_by=source.human_name, name=field.name, value=["FOO"]),
+                )

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -6,6 +6,8 @@ from unittest import TestCase
 
 from mbed_build._internal.config.config import Config, Option, Macro
 from tests._internal.config.factories import SourceFactory
+from mbed_build._internal.config.cumulative_data import CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE
+from mbed_build._internal.config.bootloader_overrides import BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE
 
 
 class TestConfigFromSources(TestCase):
@@ -50,6 +52,20 @@ class TestConfigFromSources(TestCase):
         config = Config.from_sources([source_a, source_b])
 
         self.assertEqual(config.options["bool"].help_text, "A simple bool")
+
+    def test_does_not_explode_on_cumulative_override_keys(self):
+        for key in CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE:
+            with self.subTest("Ignores {key} cumulative override"):
+                source_a = SourceFactory()
+                source_b = SourceFactory(overrides={key: "boom?"})
+                Config.from_sources([source_a, source_b])
+
+    def test_does_not_explode_on_bootloader_override_keys(self):
+        for key in BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE:
+            with self.subTest("Ignores {key} bootloader override"):
+                source_a = SourceFactory()
+                source_b = SourceFactory(overrides={key: "boom?"})
+                Config.from_sources([source_a, source_b])
 
 
 class TestOptionBuild(TestCase):

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -53,16 +53,9 @@ class TestConfigFromSources(TestCase):
 
         self.assertEqual(config.options["bool"].help_text, "A simple bool")
 
-    def test_does_not_explode_on_cumulative_override_keys(self):
-        for key in CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE:
-            with self.subTest("Ignores {key} cumulative override"):
-                source_a = SourceFactory()
-                source_b = SourceFactory(overrides={key: "boom?"})
-                Config.from_sources([source_a, source_b])
-
-    def test_does_not_explode_on_bootloader_override_keys(self):
-        for key in BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE:
-            with self.subTest("Ignores {key} bootloader override"):
+    def test_does_not_explode_on_override_keys_used_by_other_parsers(self):
+        for key in CUMULATIVE_OVERRIDE_KEYS_IN_SOURCE + BOOTLOADER_OVERRIDE_KEYS_IN_SOURCE:
+            with self.subTest("Ignores override key '{key}'"):
                 source_a = SourceFactory()
                 source_b = SourceFactory(overrides={key: "boom?"})
                 Config.from_sources([source_a, source_b])


### PR DESCRIPTION
### Description

Ability to parse bootloader overrides. This step is necessary to complete configuration parsing.

I'm not 100% sure what they're used for, but they're not part of the config used for header file. 
I've added an ability to gather the information anyway - will be useful at a later stage.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
