### PR TITLE
🐛 Configuration assembly sanitize booleans

### DIFF
--- a/mbed_build/_internal/config/config.py
+++ b/mbed_build/_internal/config/config.py
@@ -62,19 +62,23 @@ class Option:
         if isinstance(data, dict):
             return cls(
                 key=key,
-                value=data.get("value"),
+                value=_sanitize_option_value(data.get("value")),
                 macro_name=data.get("macro_name", _build_option_macro_name(key)),
                 help_text=data.get("help"),
                 set_by=source.human_name,
             )
         else:
             return cls(
-                value=data, key=key, macro_name=_build_option_macro_name(key), help_text=None, set_by=source.human_name
+                value=_sanitize_option_value(data),
+                key=key,
+                macro_name=_build_option_macro_name(key),
+                help_text=None,
+                set_by=source.human_name,
             )
 
     def set_value(self, value: Any, source: Source) -> "Option":
         """Mutate self with new value."""
-        self.value = value
+        self.value = _sanitize_option_value(value)
         self.set_by = source.human_name
         return self
 
@@ -134,6 +138,14 @@ def _build_option_macro_name(config_key: str) -> str:
     """
     sanitised_config_key = config_key.replace(".", "_").replace("-", "_").upper()
     return f"MBED_CONF_{sanitised_config_key}"
+
+
+def _sanitize_option_value(value: Any) -> Any:
+    """Converts booleans to ints, leaves everything else as is."""
+    if isinstance(value, bool):
+        return int(value)
+    else:
+        return value
 
 
 def _create_macro(config: Config, macro_str: str, source: Source) -> None:

--- a/mbed_build/_internal/mbed_tools/config.py
+++ b/mbed_build/_internal/mbed_tools/config.py
@@ -104,7 +104,7 @@ def _build_legacy_output(config: Config) -> str:
     """Output format to match that of legacy tools running mbed compile --config."""
     parameter_list = ""
     for option in _config_options_sorted_by_key(config):
-        if option.value:
+        if option.value is not None:
             parameter_list += f'{option.key} = {option.value} (macro name: "{option.macro_name}")\n'
         else:
             parameter_list += f"{option.key} has no value\n"

--- a/news/20200429.bugfix
+++ b/news/20200429.bugfix
@@ -1,0 +1,1 @@
+Display 0 values, convert bools into ints

--- a/tests/_internal/config/test_config.py
+++ b/tests/_internal/config/test_config.py
@@ -82,6 +82,14 @@ class TestOptionBuild(TestCase):
             ),
         )
 
+    def test_sanitizes_booleans_into_ints(self):
+        source = SourceFactory()
+        option = Option.build(key="target.is-cool", data={"value": True}, source=source)
+        self.assertEqual(option.value, 1)
+
+        option = Option.build(key="target.is-cool", data=False, source=source)
+        self.assertEqual(option.value, 0)
+
     def test_generates_macro_name_if_not_in_data(self):
         source = SourceFactory()
         data = {
@@ -91,6 +99,14 @@ class TestOptionBuild(TestCase):
         option = Option.build(key="update-client.storage-size", data=data, source=source)
 
         self.assertEqual(option.macro_name, "MBED_CONF_UPDATE_CLIENT_STORAGE_SIZE")
+
+
+class TestOptionSetValue(TestCase):
+    def test_sanitizes_booleans_into_ints(self):
+        option = Option.build(key="foo", data="some-data", source=SourceFactory())
+        option.set_value(False, SourceFactory())
+
+        self.assertEqual(option.value, 0)
 
 
 class TestMacroBuild(TestCase):


### PR DESCRIPTION
### Description

- Bools are converted to ints in old config - replicating that behaviour.
- I noticed that config command does not show `0` values - it should only hide `None` - fixed.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
