### PR TITLE
🐛 move mbed-build to the start of the list to fix a `pipenv install` failure

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+mbed-build = {editable = true, path = "."}
 black = "*"
 coverage = "*"
 factory_boy = "*"
@@ -16,7 +17,6 @@ mypy = ">=0.500"
 pytest = "*"
 pytest-cov = "*"
 wheel = "*"
-mbed-build = {editable = true, path = "."}
 mbed-tools-ci-scripts = "*"
 pre-commit = "*"
 

--- a/news/20200702.bugfix
+++ b/news/20200702.bugfix
@@ -1,1 +1,3 @@
 Declare zipp MIT license
+move mbed-build to the start of the list to fix a failure on `pipenv install --dev`
+


### PR DESCRIPTION
### Description

`Pipenv install --dev` fails with 
```
File "/usr/lib/python3/dist-packages/pipenv/vendor/pip9/req/req_install.py", line 514, in egg_info_path
    raise InstallationError(
pip9.exceptions.InstallationError: No files/directories in /…/mbed-build (from )
```

using :
```
pipenv v11.9.0
python v3.8.3
```

this fixes the issue.

@rwalton-arm 

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
