### PR TITLE
Fix SPDX check

### DIFF
--- a/news/20200702.bugfix
+++ b/news/20200702.bugfix
@@ -1,0 +1,1 @@
+Declare zipp MIT license

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ python-dotenv="BSD-3-Clause"
 setuptools  = "MIT"
 chardet = "LGPL-2.1 - Accepted temporarily"
 pdoc3 = "AGPL-3.0 - Accepted temporarily"
+zipp = "MIT"
 
 [AutoVersionConfig]
 CONFIG_NAME = "DEFAULT"


### PR DESCRIPTION
### Description

SPDX check is failing because it can't find an MIT license... 



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
