### PR TITLE
Remove `assert-news` from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,5 @@
 - repo: local
   hooks:
-    - id: assertnews
-      name: news file
-      entry: assert-news -l
-      language: python
-      types: [file]
-      require_serial: true
-      verbose: true
-      always_run: true
-      pass_filenames: false
-
     - id: licensing
       name: licensing
       entry: license-files

--- a/news/20200707.bugfix
+++ b/news/20200707.bugfix
@@ -1,0 +1,1 @@
+Remove `assert-news` from pre-commit checks


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
The `assert-news` with option `-l` is designed with an assumption that
there will only be one commit per PR, therefore it expects a newsfile
for every commit which is incorrect. A newsfile is expected per PR.
Therefore removing `assert-news` from pre-commit checks.

CI will still run `assert-news` on every PR and will fail if newsfile is
missing in the PR.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
