### PR TITLE
Log a more useful error message if JSON decoding fails

### DIFF
--- a/news/20200708205257.bugfix
+++ b/news/20200708205257.bugfix
@@ -1,0 +1,1 @@
+Log a more useful error message if JSON decoding fails


### PR DESCRIPTION
### Description

When JSON decoding fails we just get a fairly useless stack trace.

Log an error message containing the path to the offending JSON file.

### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
