### PR TITLE
Generate toplevel cmakelists

### DIFF
--- a/mbed_build/_internal/mbed_tools/build.py
+++ b/mbed_build/_internal/mbed_tools/build.py
@@ -8,6 +8,7 @@ import pathlib
 import click
 
 from mbed_build._internal.config_header_file import generate_config_header_file
+from mbed_build._internal.cmake_file import generate_cmakelists_file
 from mbed_build._internal.write_files import write_file
 
 
@@ -41,6 +42,11 @@ def build(mbed_target: str, program_path: str, config_only: bool) -> None:
     if not config_only:
         click.echo("Full build is not yet supported.")
     else:
+        cmakelists_file_contents = generate_cmakelists_file(mbed_target, program_path, "GCC_ARM")
+        write_file(pathlib.Path(program_path), "CMakeLists.txt", cmakelists_file_contents)
         header_file_contents = generate_config_header_file(mbed_target, program_path)
         write_file(pathlib.Path(program_path), "mbed_config.h", header_file_contents)
-        click.echo(f"The mbed_config.h file has been generated and successfully written to '{program_path}'.")
+        click.echo(
+            "The mbed_config.h and CMakeLists.txt files have been generated and successfully "
+            f"written to '{program_path}'."
+        )

--- a/mbed_build/_internal/templates/CMakeLists.tmpl
+++ b/mbed_build/_internal/templates/CMakeLists.tmpl
@@ -4,16 +4,16 @@
     as defined by targets.json.
 #}
 
-{% if target_labels %}
-    set_property(GLOBAL PROPERTY MBED_OS_TARGET_KEYS {% for label in target_labels %}{{label}};{% endfor %})
-{% endif %}
+{%- if target_labels -%}
+set_property(GLOBAL PROPERTY MBED_OS_TARGET_KEYS {% for label in target_labels %}{{label}};{% endfor %})
+{% endif -%}
 
-{% if feature_labels %}
-    set_property(GLOBAL PROPERTY MBED_OS_FEATURE_KEYS {% for label in feature_labels %}{{label}};{% endfor %})
-{% endif %}
+{%- if feature_labels -%}
+set_property(GLOBAL PROPERTY MBED_OS_FEATURE_KEYS {% for label in feature_labels %}{{label}};{% endfor %})
+{% endif -%}
 
-{% if component_labels %}
-    set_property(GLOBAL PROPERTY MBED_OS_COMPONENT_KEYS {% for label in component_labels %}{{label}};{% endfor %})
-{% endif %}
+{%- if component_labels -%}
+set_property(GLOBAL PROPERTY MBED_OS_COMPONENT_KEYS {% for label in component_labels %}{{label}};{% endfor %})
+{% endif -%}
 
 set_property(GLOBAL PROPERTY MBED_OS_TOOLCHAIN {{ toolchain_name }})

--- a/news/20200706.feature
+++ b/news/20200706.feature
@@ -1,0 +1,1 @@
+Add the top level CMakeLists.txt file generation to the build command.


### PR DESCRIPTION
### Description

Adds the generation of a CMakeLists.txt at the root of the project.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
