### PR TITLE
Add default develop profile to generated cmake config

### DIFF
--- a/mbed_build/_internal/templates/mbed_config.tmpl
+++ b/mbed_build/_internal/templates/mbed_config.tmpl
@@ -9,6 +9,7 @@ add_library(gen_config INTERFACE)
 set(MBED_TOOLCHAIN "{{toolchain_name}}" CACHE STRING "")
 set(MBED_TARGET "{{target_name}}" CACHE STRING "")
 set(MBED_CPU_CORE "{{core}}" CACHE STRING "")
+set(MBED_PROFILE "develop" CACHE STRING "")
 
 set_property(GLOBAL APPEND PROPERTY MBED_TARGET_LABELS{% for label in labels %}
     {{label}};

--- a/news/20200720102434.bugfix
+++ b/news/20200720102434.bugfix
@@ -1,0 +1,1 @@
+Add default develop profile


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Add a default profile to mimic the old tools behaviour.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
