### PR TITLE
Update mbed-targets dependency

### DIFF
--- a/news/20200720153405.bugfix
+++ b/news/20200720153405.bugfix
@@ -1,0 +1,1 @@
+Update mbed-targets dependency

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "Click==7.0",
         "Jinja2",
         "mbed-project~=2.0",
-        "mbed-targets~=1.0",
+        "mbed-targets~=1.1",
         "mbed-tools-lib~=1.2",
         "tabulate",
     ],


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
`mbed-targets` was pinned to `1.0` it's now at `1.1`.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
